### PR TITLE
Begin update of vf-header template, pull in short and long descrip

### DIFF
--- a/wp-content/plugins/embl-taxonomy/embl-taxonomy.php
+++ b/wp-content/plugins/embl-taxonomy/embl-taxonomy.php
@@ -119,6 +119,19 @@ function embl_taxonomy_get_term($term_id) {
 }
 
 /**
+ * Return uuid associated with a WordPress taxonomy term
+ */
+function embl_taxonomy_get_uuid($term_id) {
+  $term = embl_taxonomy_get_term($term_id);
+  if ( ! $term->meta )  {
+    return null;
+  }
+  $uuid = end($term->meta['embl_taxonomy_ids']);
+  return $uuid;
+}
+
+
+/**
  * Return the VF stylesheet URL
  */
 function embl_taxonomy_get_url() {

--- a/wp-content/plugins/vf-group-header-block/README.md
+++ b/wp-content/plugins/vf-group-header-block/README.md
@@ -2,6 +2,10 @@
 
 A textual introduction aside a group leader using the `vf-summary--profile` Visual Framework pattern.
 
+If a header post is not available in the VF Blocks (or is blank), this plugin will try to use the EMBL Who taxonomy term and pull the group description from the ContentHub.
+
+A "read more" to the about page will automatically be appended. 
+
 ## Configuration
 
 Related post:

--- a/wp-content/plugins/vf-group-header-block/template.php
+++ b/wp-content/plugins/vf-group-header-block/template.php
@@ -11,6 +11,25 @@ $heading = preg_replace(
   $heading
 );
 
+// if heading is empty, use the contenthub description
+if (vf_html_empty($heading)) {
+  if ( class_exists('VF_Cache') ) {
+    $uuid = vf__get_site_uuid();
+    $heading = '<h1 class="vf-lede">' . VF_Cache::get_post('https://dev.beta.embl.org/api/v1/pattern.html?filter-content-type=profiles&filter-uuid='.$uuid.'&pattern=node-teaser&source=contenthub') . '</h1>';
+    $heading = preg_replace(
+      '#<p>#',
+      '<h1 class="vf-lede">',
+      $heading
+    );
+    $heading = preg_replace(
+      '#</p>#',
+      ' <a class="vf-link" href="'. get_site_url() .'/about">Read more</a></h1>',
+      $heading
+    );
+  }
+}
+
+
 $content = $vf_plugin->api_html();
 
 ?>

--- a/wp-content/plugins/vf-group-header-block/template.php
+++ b/wp-content/plugins/vf-group-header-block/template.php
@@ -23,7 +23,7 @@ if (vf_html_empty($heading)) {
     );
     $heading = preg_replace(
       '#</p>#',
-      ' <a class="vf-link" href="'. get_site_url() .'/about">Read more</a></h1>',
+      ' <a class="vf-link" href="'.get_site_url().'/about">Read more</a>.</h1>',
       $heading
     );
   }

--- a/wp-content/themes/vf-wp/functions/theme.php
+++ b/wp-content/themes/vf-wp/functions/theme.php
@@ -208,4 +208,29 @@ function vf__nav_menu_link_attributes($atts, $item, $args, $depth) {
   return $atts;
 }
 
+
+/**
+ * Shorthand to safely query the UUID of the active "who" term, if set
+ */
+function vf__get_site_uuid() {
+
+  // first we want to be sure the taxonomy plugin is enabled
+  if ( ! function_exists('embl_taxonomy_get_uuid')) {
+    print '<!-- To get the UUID, you must enable the EMBL Taxonomy plugin -->' . PHP_EOL;
+    return null;
+  }
+
+  $term_id = get_field('embl_taxonomy_term_what', 'option');
+
+  if ( ! $term_id ) {
+    print '<!-- If you wish to get the group UUID, you must set the group\'s "what" at /wp-admin/options-general.php?page=embl-settings -->';
+
+  }
+
+  $uuid = embl_taxonomy_get_uuid($term_id);
+
+  return $uuid;
+}
+
+
 ?>

--- a/wp-content/themes/vf-wp/page.php
+++ b/wp-content/themes/vf-wp/page.php
@@ -4,10 +4,14 @@ get_template_part('partials/header');
 
 the_post();
 
-$vf_group_header = VF_Plugin::get_plugin('vf_group_header');
+// Only show group long description on front page
+if (is_front_page()) {
 
-if (class_exists('VF_Group_Header')) {
-  VF_Plugin::render($vf_group_header);
+  $vf_group_header = VF_Plugin::get_plugin('vf_group_header');
+
+  if (class_exists('VF_Group_Header')) {
+    VF_Plugin::render($vf_group_header);
+  }
 }
 
 ?>

--- a/wp-content/themes/vf-wp/partials/vf-masthead.php
+++ b/wp-content/themes/vf-wp/partials/vf-masthead.php
@@ -7,6 +7,8 @@
           if ( class_exists('VF_Cache') ) {
             $uuid = vf__get_site_uuid();
             $short_description = VF_Cache::get_post('https://dev.beta.embl.org/api/v1/pattern.html?filter-content-type=profiles&filter-uuid='.$uuid.'&pattern=node-strapline&source=contenthub');
+            // we don't want any of the contentHub `div`s. `span`s are OK though
+            $short_description = str_replace(array('<div', '</div>'), array('<span', '</span>'), $short_description);
             print $short_description;
           }
           ?>

--- a/wp-content/themes/vf-wp/partials/vf-masthead.php
+++ b/wp-content/themes/vf-wp/partials/vf-masthead.php
@@ -1,12 +1,18 @@
-<div class="vf-masthead">
-  <div class="vf-masthead__inner">
+<div class="vf-masthead" style="background-color: var(--vf-masthead__color--background, var(--vf-masthead__color--background-default)); color: var(--vf-masthead__color--foreground, var(--vf-masthead__color--foreround-default) );">
     <div class="vf-masthead__title">
-      <div class="vf-masthead__title-inner">
-        <h1 class="vf-masthead__heading | text--heading--xl">
+        <h1 class="vf-masthead__heading">
           <a class="vf-masthead__heading__link" href="<?php echo home_url(); ?>"><?php echo esc_html(get_bloginfo('name')); ?></a>
+          <span class="vf-masthead__heading--additional">
+          <?php
+          if ( class_exists('VF_Cache') ) {
+            $uuid = vf__get_site_uuid();
+            $short_description = VF_Cache::get_post('https://dev.beta.embl.org/api/v1/pattern.html?filter-content-type=profiles&filter-uuid='.$uuid.'&pattern=node-strapline&source=contenthub');
+            print $short_description;
+          }
+          ?>
+          </span>
         </h1>
-      </div>
     </div>
-  </div>
 </div>
+
 <!--/vf-masthead-->


### PR DESCRIPTION
This PR:

- Pulls from a group's EMBL.org Profile on the ContentHub
    - short description
    - long description
- Begins to update the group header to reflect changes in the VF
- Changes `WP_GROUP_TEAM_SHORT_DESCRIPTION` to be `WP_GROUP_TEAM_LONG_DESCRIPTION`

Notes:
- Header will look a bit "off" until we cut alpha.5 of the VF
- The default install set the Group Description in VF Blocks (for Web Dev), so it won't pull the ContentHub description