### PR TITLE
removes embl specific divs and classes

### DIFF
--- a/wp-content/themes/vf-wp/partials/header.php
+++ b/wp-content/themes/vf-wp/partials/header.php
@@ -1,11 +1,9 @@
 <?php get_template_part('partials/head'); ?>
 <?php vf_header(); ?>
 
-<div class="vf-inlay">
-  <header class="embl-group-header__header embl-group-page--vf-header--bg-color">
-    <?php get_template_part('partials/vf-masthead'); ?>
-    <div class="embl-group-header__navigation embl-group-header__navigation--main">
-      <?php get_template_part('partials/vf-navigation'); ?>
-    </div>
-  </header>
-</div>
+
+<header class="vf-header">
+  <?php get_template_part('partials/vf-masthead'); ?>
+  <?php get_template_part('partials/vf-navigation'); ?>
+</header>
+

--- a/wp-content/themes/vf-wp/partials/header.php
+++ b/wp-content/themes/vf-wp/partials/header.php
@@ -2,7 +2,7 @@
 <?php vf_header(); ?>
 
 
-<header class="vf-header">
+<header class="vf-header vf-header--inlay">
   <?php get_template_part('partials/vf-masthead'); ?>
   <?php get_template_part('partials/vf-navigation'); ?>
 </header>


### PR DESCRIPTION
As the masthead has been made more malleable with `vf-header` we no longer need any `embl-` specific CSS or additional classes as it should all 'just work'

Only to be merged when `alpha.6` has been released