### PR TITLE
Fix bleeding of nav bar

### DIFF
--- a/assets/scss/hacks.scss
+++ b/assets/scss/hacks.scss
@@ -1,23 +1,9 @@
-/*! VF-WP - Main (Sass-compiled) */
-/**
- * Reset page grid when VF container patterns require a wrapping div
- */
-.vfwp-column-reset {
-  grid-column: 1 / -1;
-}
-
-/**
- * Ignore width and height attributes on attachments
- */
-img[class*="attachment"] {
-  width: auto;
-  height: auto;
-}
-
 /*! VF-WP - Hacks (Sass-compiled) */
+
 /**
  * There's no escaping it, sometimes you need workarounds.
  */
+
 /**
  * Fix an issue where the ::before pseudo element needs a parent element with
  * a background-color. However in the WP theme, that's <body>, and we can't

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -15,3 +15,5 @@ img[class*="attachment"] {
   width: auto;
   height: auto;
 }
+
+@import 'hacks.scss';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vf-wp",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2209,7 +2209,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2230,12 +2231,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2250,17 +2253,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2377,7 +2383,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2389,6 +2396,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2403,6 +2411,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2410,12 +2419,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -2434,6 +2445,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2514,7 +2526,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2526,6 +2539,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2611,7 +2625,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2647,6 +2662,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2666,6 +2682,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2709,12 +2726,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/wp-content/themes/vf-wp/assets/css/hacks.css
+++ b/wp-content/themes/vf-wp/assets/css/hacks.css
@@ -1,19 +1,3 @@
-/*! VF-WP - Main (Sass-compiled) */
-/**
- * Reset page grid when VF container patterns require a wrapping div
- */
-.vfwp-column-reset {
-  grid-column: 1 / -1;
-}
-
-/**
- * Ignore width and height attributes on attachments
- */
-img[class*="attachment"] {
-  width: auto;
-  height: auto;
-}
-
 /*! VF-WP - Hacks (Sass-compiled) */
 /**
  * There's no escaping it, sometimes you need workarounds.


### PR DESCRIPTION
Fix an issue where the ::before pseudo element needs a parent element with
a background-color. However in the WP theme, that's <body>, and we can't
z-index under it :(