### PR TITLE
the one where Stuart removes the grid wrapper

### DIFF
--- a/wp-content/plugins/vf-breadcrumbs-container/template.php
+++ b/wp-content/plugins/vf-breadcrumbs-container/template.php
@@ -1,5 +1,3 @@
-<div class="embl-grid">
-  <nav class="vf-breadcrumbs embl-breadcrumbs-lookup" aria-label="Breadcrumb" data-embl-js-breadcrumbs-lookup>
-    <div class="vf-text embl-breadcrumbs-lookup--loading-text"></div>
-  </nav>
-</div>
+<nav class="vf-breadcrumbs embl-breadcrumbs-lookup" aria-label="Breadcrumb" data-embl-js-breadcrumbs-lookup>
+  <div class="vf-text embl-breadcrumbs-lookup--loading-text"></div>
+</nav>


### PR DESCRIPTION
This will break unless we edit `vf-breadcrumbs` in vf-core to make `grid-column` go from `1 / -1` to `2 / -2`

(unless I get the overhaul of the grid system in place - then it won't need `grid-column`