### PR TITLE
the one where we try to get categories list to use vf- name-spacing

### DIFF
--- a/wp-content/themes/vf-wp/functions/widgets.php
+++ b/wp-content/themes/vf-wp/functions/widgets.php
@@ -10,7 +10,7 @@ function vf__widgets_init() {
   $widgets = array(
     'WP_Widget_Archives',
     'WP_Widget_Calendar',
-    // 'WP_Widget_Categories',
+    'WP_Widget_Categories',
     'WP_Widget_Custom_HTML',
     // 'WP_Widget_Links',
     'WP_Widget_Media_Audio',


### PR DESCRIPTION
I'm not entirely sure if this would be enough to get the Categories list to pick up:

- `vf-links__list | vf-list`
- `vf-list__item`

but _I think_ it is.