### PR TITLE
Fix/issue 4

### DIFF
--- a/wp-content/plugins/vf-group-header-block/index.php
+++ b/wp-content/plugins/vf-group-header-block/index.php
@@ -74,6 +74,45 @@ class VF_Group_Header extends VF_Plugin {
     );
   }
 
+  function heading_html() {
+    $heading = get_field('vf_group_header_heading', $this->post->ID);
+    $heading = trim($heading);
+
+    $heading = preg_replace(
+      '#<h1[^>]*?>#',
+      '<h1 class="vf-lede">',
+      $heading
+    );
+
+    if ( ! vf_html_empty($heading) || ! class_exists('VF_Cache')) {
+      return $heading;
+    }
+
+    // if heading is empty, use the contenthub description
+    $uuid = vf__get_site_uuid();
+
+    $url = VF_Cache::get_api_url();
+    $url .= '/pattern.html?filter-content-type=profiles';
+    $url .= "&filter-uuid={$uuid}";
+    $url .= '&pattern=node-teaser&source=contenthub';
+
+    $heading = VF_Cache::get_post($url);
+
+    $heading = preg_replace(
+      '#<p>#',
+      '<h1 class="vf-lede">',
+      $heading
+    );
+
+    $heading = preg_replace(
+      '#</p>#',
+      ' <a class="vf-link" href="'.home_url('/about/').'">' . __('Read more', 'vfwp') . '</a>.</h1>',
+      $heading
+    );
+
+    return $heading;
+  }
+
   function admin_head() {
 ?>
 <style>

--- a/wp-content/plugins/vf-group-header-block/template.php
+++ b/wp-content/plugins/vf-group-header-block/template.php
@@ -3,33 +3,7 @@
 global $post, $vf_plugin;
 if ( ! $vf_plugin instanceof VF_Group_Header) return;
 
-$heading = trim(get_field('vf_group_header_heading', $post->ID));
-
-$heading = preg_replace(
-  '#<h1[^>]*?>#',
-  '<h1 class="vf-lede">',
-  $heading
-);
-
-// if heading is empty, use the contenthub description
-if (vf_html_empty($heading)) {
-  if ( class_exists('VF_Cache') ) {
-    $uuid = vf__get_site_uuid();
-    $heading = VF_Cache::get_post('https://dev.beta.embl.org/api/v1/pattern.html?filter-content-type=profiles&filter-uuid='.$uuid.'&pattern=node-teaser&source=contenthub');
-    $heading = preg_replace(
-      '#<p>#',
-      '<h1 class="vf-lede">',
-      $heading
-    );
-    $heading = preg_replace(
-      '#</p>#',
-      ' <a class="vf-link" href="'.get_site_url().'/about">Read more</a>.</h1>',
-      $heading
-    );
-  }
-}
-
-
+$heading = $vf_plugin->heading_html();
 $content = $vf_plugin->api_html();
 
 ?>

--- a/wp-content/plugins/vf-wp/index.php
+++ b/wp-content/plugins/vf-wp/index.php
@@ -56,8 +56,6 @@ class VF_WP {
     register_activation_hook(__FILE__, array($this, 'activate'));
     register_deactivation_hook(__FILE__, array($this, 'deactivate'));
 
-    add_action('acf/init', array($this, 'acf_init'));
-
     // ACF load and save setup - saving only useful for development
     add_filter(
       'acf/settings/load_json',
@@ -118,32 +116,6 @@ class VF_WP {
     if ($vf_containers instanceof VF_Containers) {
       $vf_containers->deactivate();
     }
-  }
-
-  /**
-   * Action `acf/init`
-   * Add field for Content Hub API URL
-   */
-  function acf_init() {
-    acf_add_local_field(
-      array(
-        'parent' => 'group_embl_setting',
-        'key' => 'field_vf_api_url',
-        'label' => __('EMBL Content Hub', 'vfwp'),
-        'name' => 'vf_api_url',
-        'type' => 'url',
-        'instructions' => '',
-        'required' => 0,
-        'conditional_logic' => 0,
-        'wrapper' => array(
-          'width' => '',
-          'class' => '',
-          'id' => '',
-        ),
-        'default_value' => '',
-        'placeholder' => '',
-      )
-    );
   }
 
   /**

--- a/wp-content/plugins/vf-wp/vf-cache.php
+++ b/wp-content/plugins/vf-wp/vf-cache.php
@@ -25,6 +25,15 @@ class VF_Cache {
   }
 
   /**
+   * Return the EMBL Content Hub API URL from ACF options page
+   * without trailing slash
+   */
+  static public function get_api_url() {
+    $url = get_field('vf_api_url', 'option');
+    return rtrim(trim($url), '/\\');
+  }
+
+  /**
    * A more reliable way to fetch remote HTML
    * Derrived from https://www.experts-exchange.com/questions/26187506/Function-file-get-contents-connection-time-out.html
    */
@@ -139,6 +148,7 @@ class VF_Cache {
    */
   public function initialize() {
     add_action('init', array($this, 'init'));
+    add_action('acf/init', array($this, 'acf_init'));
     if (is_admin()) {
       add_filter(
         'manage_' . $this->post_type . '_posts_columns',
@@ -234,6 +244,32 @@ class VF_Cache {
       'query_var'         => false,
       'can_export'        => false
     ));
+  }
+
+  /**
+   * Action `acf/init`
+   * Add field for Content Hub API URL
+   */
+  public function acf_init() {
+    acf_add_local_field(
+      array(
+        'parent' => 'group_embl_setting',
+        'key' => 'field_vf_api_url',
+        'label' => __('EMBL Content Hub', 'vfwp'),
+        'name' => 'vf_api_url',
+        'type' => 'url',
+        'instructions' => '',
+        'required' => 0,
+        'conditional_logic' => 0,
+        'wrapper' => array(
+          'width' => '',
+          'class' => '',
+          'id' => '',
+        ),
+        'default_value' => '',
+        'placeholder' => '',
+      )
+    );
   }
 
   /**

--- a/wp-content/plugins/vf-wp/vf-plugin.php
+++ b/wp-content/plugins/vf-wp/vf-plugin.php
@@ -138,9 +138,11 @@ class VF_Plugin {
    * Return API URL base for all instances of the plugin
    */
   public function api_url(array $query_vars = array()) {
-    if (empty($this->API)) return;
-    $url = trim(get_field('vf_api_url', 'option'));
-    $url = rtrim($url, '/\\') . '/pattern.html';
+    if (empty($this->API)) {
+      return;
+    }
+    $url = VF_Cache::get_api_url();
+    $url .= '/pattern.html';
     if (is_array($this->API)) {
       $url = add_query_arg($this->API, $url);
     }


### PR DESCRIPTION
Simple fix for issue #4 

Added a method to return the option value from the ACF field.

```php
VF_Cache::get_api_url();
```

I moved where this field is registered from `VF_WP` to `VF_Cache` as it seems a better place for it and keeps the root plugin class tidy.

I moved some plugin logic for **VF Group Header** from `template.php` to its `index.php`. Then replaced the hard-coded URL.