### PR TITLE
CHORE - Use vf-u-grid--reset

### DIFF
--- a/wp-content/plugins/vf-ebi-global-footer-container/template.php
+++ b/wp-content/plugins/vf-ebi-global-footer-container/template.php
@@ -7,7 +7,7 @@ $content = $vf_plugin->api_html();
 
 if ( ! empty($content)) {
 ?>
-<div <?php $vf_plugin->api_attr(array('class' => 'vfwp-column-reset')); ?>>
+<div <?php $vf_plugin->api_attr(array('class' => 'vf-u-grid--reset')); ?>>
   <?php echo $content; ?>
 </div>
 <?php } ?>

--- a/wp-content/plugins/vf-ebi-global-header-container/template.php
+++ b/wp-content/plugins/vf-ebi-global-header-container/template.php
@@ -7,7 +7,7 @@ $content = $vf_plugin->api_html();
 
 if ( ! empty($content)) {
 ?>
-<div <?php $vf_plugin->api_attr(array('class' => 'vfwp-column-reset')); ?>>
+<div <?php $vf_plugin->api_attr(array('class' => 'vf-u-grid--reset')); ?>>
   <?php echo $content; ?>
 </div>
 <?php } ?>

--- a/wp-content/plugins/vf-embl-news-container/template.php
+++ b/wp-content/plugins/vf-embl-news-container/template.php
@@ -8,7 +8,7 @@ $content = $vf_plugin->api_html();
 if ( ! empty($content)) {
 ?>
 
-<div class="vfwp-column-reset vf-body vf-body__additional-content vf-u-background-color-ui--white">
+<div class="vf-u-grid--reset vf-body vf-body__additional-content vf-u-background-color-ui--white">
   <hr class="vf-divider">
   <section class="vf-news-container | embl-grid embl-grid--has-sidebar">
     <div class="vf-section-header">

--- a/wp-content/plugins/vf-global-footer-container/template.php
+++ b/wp-content/plugins/vf-global-footer-container/template.php
@@ -7,7 +7,7 @@ $content = $vf_plugin->api_html();
 
 if ( ! empty($content)) {
 ?>
-<div <?php $vf_plugin->api_attr(array('class' => 'vfwp-column-reset')); ?>>
+<div <?php $vf_plugin->api_attr(array('class' => 'vf-u-grid--reset')); ?>>
   <?php echo $content; ?>
 </div>
 <?php } ?>

--- a/wp-content/plugins/vf-global-header-container/template.php
+++ b/wp-content/plugins/vf-global-header-container/template.php
@@ -8,7 +8,7 @@ $content = $vf_plugin->api_html();
 if ( ! empty($content)) {
 ?>
 <header class="vf-header">
-  <div <?php $vf_plugin->api_attr(array('class' => 'vfwp-column-reset')); ?>>
+  <div <?php $vf_plugin->api_attr(array('class' => 'vf-u-grid--reset')); ?>>
     <?php echo $content; ?>
   </div>
 </header>

--- a/wp-content/themes/vf-wp/assets/css/main.css
+++ b/wp-content/themes/vf-wp/assets/css/main.css
@@ -1,12 +1,5 @@
 /*! VF-WP - Main (Sass-compiled) */
 /**
- * Reset page grid when VF container patterns require a wrapping div
- */
-.vfwp-column-reset {
-  grid-column: 1 / -1;
-}
-
-/**
  * Ignore width and height attributes on attachments
  */
 img[class*="attachment"] {

--- a/wp-content/themes/vf-wp/assets/scss/main.scss
+++ b/wp-content/themes/vf-wp/assets/scss/main.scss
@@ -1,13 +1,6 @@
 /*! VF-WP - Main (Sass-compiled) */
 
 /**
- * Reset page grid when VF container patterns require a wrapping div
- */
-.vfwp-column-reset {
-  grid-column: 1 / -1;
-}
-
-/**
  * Ignore width and height attributes on attachments
  */
 


### PR DESCRIPTION
This drops `vfwp-column-reset` in favour of using `vf-u-grid--reset` from https://visual-framework.github.io/vf-core/components/detail/vf-utility-classes.html

`vfwp-column-reset` preceeded the the vf-core css, but it serves the same purpose