### PR TITLE
add opt-in option for CDN assets

### DIFF
--- a/wp-content/plugins/vf-gutenberg/README.md
+++ b/wp-content/plugins/vf-gutenberg/README.md
@@ -29,12 +29,14 @@ Most of the VF blocks are rendered using an `<iframe>` within the Gutenberg edit
 
 ## Global Options
 
-The global options `vf_cdn_stylesheet` and `vf_cdn_javascript` are added to the `vf-settings` options page. Template functions exist for convenience. They will return `null` if the option is empty.
+The global options `vf_cdn_stylesheet` and `vf_cdn_javascript` are added to the `vf-settings` options page. Template functions will return `null` if the option is empty, or the opt-in option is zero.
 
 ```php
 $stylesheet = vf_get_stylesheet();
 $javascript = vf_get_javascript();
 ```
+
+The `vf_cdn_stylesheet_optin` and `vf_cdn_javascript_optin` options must be toggled on (value: `1`) to use these assets.
 
 ## WordPress Core Blocks
 

--- a/wp-content/plugins/vf-gutenberg/includes/settings.php
+++ b/wp-content/plugins/vf-gutenberg/includes/settings.php
@@ -34,32 +34,30 @@ class VF_Gutenberg_Settings {
           'label' => 'CDN Stylesheet',
           'name' => 'vf_cdn_stylesheet',
           'type' => 'url',
-          'instructions' => '',
-          'required' => 0,
-          'conditional_logic' => 0,
-          'wrapper' => array(
-            'width' => '',
-            'class' => '',
-            'id' => '',
-          ),
-          'default_value' => '',
-          'placeholder' => '',
+        ),
+        array(
+          'key' => 'field_vf_cdn_stylesheet_optin',
+          'label' => '',
+          'name' => 'vf_cdn_stylesheet_optin',
+          'type' => 'true_false',
+          'message' => 'Include CDN Stylesheet on front-end',
+          'default_value' => 0,
+          'ui' => 1,
         ),
         array(
           'key' => 'field_vf_cdn_javascript',
           'label' => 'CDN JavaScript',
           'name' => 'vf_cdn_javascript',
           'type' => 'url',
-          'instructions' => '',
-          'required' => 0,
-          'conditional_logic' => 0,
-          'wrapper' => array(
-            'width' => '',
-            'class' => '',
-            'id' => '',
-          ),
-          'default_value' => '',
-          'placeholder' => '',
+        ),
+        array(
+          'key' => 'field_vf_cdn_javascript_optin',
+          'label' => '',
+          'name' => 'vf_cdn_javascript_optin',
+          'type' => 'true_false',
+          'message' => 'Include CDN JavaScript on front-end',
+          'default_value' => 0,
+          'ui' => 1,
         ),
       ),
       'location' => array(
@@ -92,6 +90,10 @@ function vf_get_stylesheet() {
   if ( ! function_exists('get_field')) {
     return null;
   }
+  $optin = (bool) get_field('vf_cdn_stylesheet_optin', 'option');
+  if (!$optin) {
+    return null;
+  }
   $url = trim(get_field('vf_cdn_stylesheet', 'option'));
   return empty($url) ? null : $url;
 }
@@ -101,6 +103,10 @@ function vf_get_stylesheet() {
  */
 function vf_get_javascript() {
   if ( ! function_exists('get_field')) {
+    return null;
+  }
+  $optin = (bool) get_field('vf_cdn_javascript_optin', 'option');
+  if (!$optin) {
     return null;
   }
   $url = trim(get_field('vf_cdn_javascript', 'option'));

--- a/wp-content/themes/vf-wp/functions/theme.php
+++ b/wp-content/themes/vf-wp/functions/theme.php
@@ -166,20 +166,21 @@ function vf__wp_enqueue_scripts() {
     'all'
   );
 
+  // Enqueue VF JS
+  wp_enqueue_script(
+    'vf-scripts',
+    $dir . '/assets/scripts/scripts.js',
+    array(),
+    $theme->version,
+    true
+  );
+
   // Register script - let plugins enqueue as necessary
   wp_register_script(
     'accessible-autocomplete',
     $dir . '/assets/js/accessible-autocomplete.min.js',
     array(),
     '1.6.2',
-    true
-  );
-  // Register VF JS
-  wp_register_script(
-    'vf-scripts',
-    $dir . '/assets/scripts/scripts.js',
-    array(),
-    $theme->version,
     true
   );
   wp_register_style(


### PR DESCRIPTION
Added two new options:

* `vf_cdn_stylesheet_optin`
* `vf_cdn_javascript_optin`

Values must be `1` before the CDN assets are enqueued on the front-end. By default we're now building local stylesheet and scripts so the external assets are now optional.

Also fixed enquement of `scripts.js` (was being registered but not used).