### PR TITLE
fix/issue-77

### DIFF
--- a/wp-content/plugins/vf-wp/vf-cache.php
+++ b/wp-content/plugins/vf-wp/vf-cache.php
@@ -309,7 +309,7 @@ xhr.send('<?php echo build_query($data); ?>');
             wp_insert_post(array(
             'post_author'  => 1,
             'post_name'    => $key,
-            'post_title'   => $data['url'],
+            'post_title'   => basename(urldecode($data['url'])),
             'post_type'    => 'vf_cache',
             'post_status'  => 'publish',
             'post_content' => '',


### PR DESCRIPTION
Fixes #77 

The WP Admin table will show an icon to illustrate success or failure of the last server-side request (hover text to see error code in title attribute).

The CURL or HTTP error code is saved in `vf_cache_error` post meta.

JavaScript fallback is only used when cache is empty.