### PR TITLE
feature/vf-containers-editor

### DIFF
--- a/vf-components/vfwp-admin/vfwp-admin.css
+++ b/vf-components/vfwp-admin/vfwp-admin.css
@@ -219,6 +219,41 @@
   width: 10%;
 }
 
+.post-type-vf_block .edit-post-visual-editor,
+.post-type-vf_container .edit-post-visual-editor {
+  -ms-flex-preferred-size: auto;
+      flex-basis: auto;
+  -webkit-box-flex: 0;
+      -ms-flex-positive: 0;
+          flex-grow: 0;
+  -ms-flex-negative: 1;
+      flex-shrink: 1;
+}
+
+.post-type-vf_block .editor-block-list__layout,
+.post-type-vf_container .editor-block-list__layout {
+  min-height: 10px;
+}
+
+.post-type-vf_block .edit-post-layout__metaboxes,
+.post-type-vf_container .edit-post-layout__metaboxes {
+  -webkit-box-flex: 1;
+      -ms-flex-positive: 1;
+          flex-grow: 1;
+}
+
+.post-type-vf_block .edit-post-layout__metaboxes:empty,
+.post-type-vf_container .edit-post-layout__metaboxes:empty {
+  -webkit-box-flex: 0;
+      -ms-flex-positive: 0;
+          flex-grow: 0;
+}
+
+.post-type-vf_block .edit-post-layout__metaboxes .acf-hndle-cog,
+.post-type-vf_container .edit-post-layout__metaboxes .acf-hndle-cog {
+  display: none !important;
+}
+
 .editor-post-title__block {
   --vf-text-margin--bottom: 0;
 }

--- a/vf-components/vfwp-admin/vfwp-admin.css
+++ b/vf-components/vfwp-admin/vfwp-admin.css
@@ -169,6 +169,10 @@
  * Version: 0.0.1
  * Location: components/vfwp-admin
  */
+.vfwp-notice a {
+  text-decoration: none;
+}
+
 .has-extra-large-font-size {
   font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
   font-size: 32px;

--- a/vf-components/vfwp-admin/vfwp-admin.scss
+++ b/vf-components/vfwp-admin/vfwp-admin.scss
@@ -45,6 +45,35 @@
   }
 }
 
+.post-type-vf_block,
+.post-type-vf_container {
+  // Auto-shrink Gutenberg editor
+  .edit-post-visual-editor {
+    flex-basis: auto;
+    flex-grow: 0;
+    flex-shrink: 1;
+  }
+
+  // Ensure some visual spacing
+  .editor-block-list__layout {
+    min-height: 10px;
+  }
+
+  // Auto-grow the post meta boxes below
+  .edit-post-layout__metaboxes {
+    flex-grow: 1;
+
+    &:empty {
+      flex-grow: 0;
+    }
+
+    // Hide ACF field settings
+    .acf-hndle-cog {
+      display: none !important;
+    }
+  }
+}
+
 // Post title as `h1` heading
 .editor-post-title__block {
   --vf-text-margin--bottom: 0;

--- a/vf-components/vfwp-admin/vfwp-admin.scss
+++ b/vf-components/vfwp-admin/vfwp-admin.scss
@@ -14,6 +14,12 @@
  * Location: #{map-get($componentInfo, 'location')}
  */
 
+.vfwp-notice {
+  a {
+    text-decoration: none;
+  }
+}
+
 @mixin editor-font-sizes {
   .has-extra-large-font-size {
     @include set-type(text-body--1);

--- a/wp-content/plugins/vf-wp/vf-acf.php
+++ b/wp-content/plugins/vf-wp/vf-acf.php
@@ -11,6 +11,10 @@ class VF_ACF {
       'acf/settings/show_admin',
       array($this, 'acf_settings_show_admin')
     );
+    add_action(
+      'admin_notices',
+      array($this, 'admin_notices')
+    );
     add_filter(
       'acf/settings/save_json',
       array($this, 'acf_settings_save_json'),
@@ -31,6 +35,38 @@ class VF_ACF {
       return false;
     }
     return true;
+  }
+
+  /**
+   * Action: add notice to ACF screens
+   */
+  public function admin_notices() {
+    if ( ! function_exists('get_current_screen')) {
+      return;
+    }
+    // if (vf_debug()) {
+    //   return;
+    // }
+    $ids = array(
+      'edit-acf-field-group',
+      'acf-field-group',
+    );
+    $screen = get_current_screen();
+    if ( ! in_array($screen->id, $ids)) {
+      return;
+    }
+    printf('<div class="%1$s"><h3><b>%2$s</b></h3><p><b>%3$s</b> %4$s</p><p>%5$s</p></div>',
+      esc_attr('notice notice-warning | vfwp-notice'),
+      esc_html__('Attention!', 'vfwp'),
+      esc_html__('Advanced custom fields should not be synced or edited on live websites.', 'vfwp'),
+      esc_html__('Only configure them during development of plugins or themes. Visit the repository below to find developer documentation:', 'vfwp'),
+      sprintf(
+        '<a href="%1$s" target="_blank">%2$s %3$s</a>',
+        esc_attr('https://github.com/visual-framework/vf-wp'),
+        '<span class="dashicons dashicons-external"></span>',
+        esc_html__('VF-WP on GitHub', 'vfwp')
+      )
+    );
   }
 
   /**

--- a/wp-content/plugins/vf-wp/vf-plugin.php
+++ b/wp-content/plugins/vf-wp/vf-plugin.php
@@ -113,7 +113,7 @@ class VF_Plugin {
     if ( ! $this->post instanceof WP_Post) {
       return;
     }
-    if (file_exists("{$this->dir()}group_{$this->post->post_name}.json")) {
+    if ($this->is_acf()) {
       add_filter(
         'acf/settings/load_json',
         array($this, 'acf_settings_load_json')
@@ -152,6 +152,21 @@ class VF_Plugin {
   }
 
   /**
+   * Return true if plugin has ACF configuration
+   */
+  public function is_acf() {
+    $path = "{$this->dir()}group_{$this->post->post_name}.json";
+    return file_exists($path);
+  }
+
+  /**
+   * Return true if plugin has API configuration
+   */
+  public function is_api() {
+    return empty($this->API) === false;
+  }
+
+  /**
    * Return full plugin directory path (with trailing slash)
    */
   public function dir() {
@@ -174,8 +189,8 @@ class VF_Plugin {
    * Return API URL base for all instances of the plugin
    */
   public function api_url(array $query_vars = array()) {
-    if (empty($this->API)) {
-      return;
+    if ( ! $this->is_api()) {
+      return '';
     }
     $url = VF_Cache::get_api_url();
     $url .= '/pattern.html';

--- a/wp-content/plugins/vf-wp/vf-type.php
+++ b/wp-content/plugins/vf-wp/vf-type.php
@@ -38,6 +38,10 @@ class VF_Type {
       'template_redirect',
       array($this, 'template_redirect')
     );
+    add_filter('allowed_block_types',
+      array($this, 'allowed_block_types'),
+      10, 2
+    );
     add_filter(
       'acf/location/rule_types',
       array($this, 'acf_rule_types')
@@ -139,7 +143,8 @@ class VF_Type {
       'public'             => false,
       'show_ui'            => true,
       'show_in_admin_bar'  => false,
-      'supports'           => array('title'),
+      'show_in_rest'       => true,
+      'supports'           => array('title', 'editor'),
       'rewrite'            => false,
       'publicly_queryable' => true,
       'query_var'          => true,
@@ -157,6 +162,17 @@ class VF_Type {
         $wp_query->set_404();
       }
     }
+  }
+
+  /**
+   * Disallow all Gutenberg blocks for the post type by default.
+   * Effectively disabling the editor.
+   */
+  public function allowed_block_types($allowed, $post) {
+    if ($post->post_type === $this->post_type) {
+      return false;
+    }
+    return $allowed;
   }
 
   /**

--- a/wp-content/plugins/vf-wp/vf-type.php
+++ b/wp-content/plugins/vf-wp/vf-type.php
@@ -250,7 +250,7 @@ class VF_Type {
     $offset = array_search('date', array_keys($columns));
     $columns = array_merge(
       array_slice($columns, 0, $offset),
-      array('vf_template' => __('Template', 'vfwp')),
+      array('vf_meta' => __('Meta', 'vfwp')),
       array_slice($columns, $offset)
     );
     return $columns;
@@ -260,16 +260,56 @@ class VF_Type {
    * Action: output template path for posts table in custom column
    */
   public function posts_custom_column($column, $post_id) {
-    if ($column !== 'vf_template') return;
-    $plugin = VF_Plugin::get_plugin(get_post_field('post_name', $post_id));
-    if ( ! $plugin) return;
-    $path = $plugin->template();
-    if ( ! $path) return;
-    $offset = strpos($path, 'wp-content');
-    if ($offset) {
-      $path = substr($path, $offset + 10);
+    if ($column !== 'vf_meta') {
+      return;
     }
-    echo $path;
+    $post_name = get_post_field('post_name', $post_id);
+    $plugin = VF_Plugin::get_plugin($post_name);
+    if ( ! $plugin) {
+      return;
+    }
+    $icons = array();
+    $path = $plugin->template();
+    if ($path) {
+      $offset = strpos($path, 'wp-content');
+      if ($offset) {
+        $path = substr($path, $offset + 10);
+      }
+      $icons[] = '<span class="dashicons dashicons-edit"></span> <abbr title="'
+        . esc_attr(sprintf(
+            __('Plugin has %1$s', 'vfwp'),
+            sprintf(
+              __('PHP template: %1$s', 'vfwp'),
+              $path
+            )
+          ))
+        . '">'
+        . esc_html__('PHP', 'vfwp')
+        . '</abbr>';
+    }
+    if ($plugin->is_acf()) {
+      $icons[] = '<span class="dashicons dashicons-admin-generic"></span> <abbr title="'
+        . esc_attr(sprintf(
+            __('Plugin has %1$s', 'vfwp'),
+            __('Advanced Custom Fields configuration', 'vfwp')
+          ))
+        . '">'
+        . esc_html__('ACF', 'vfwp')
+        . '</abbr>';
+    }
+    if ($plugin->is_api()) {
+      $icons[] = '<span class="dashicons dashicons-external"></span> <abbr title="'
+        . esc_attr(sprintf(
+            __('Plugin has %1$s', 'vfwp'),
+            __('Content Hub API integration', 'vfwp')
+          ))
+        . '">'
+        . esc_html__('API', 'vfwp')
+        . '</abbr>';
+    }
+    if ( ! empty($icons)) {
+      echo '<p>', implode('&nbsp; ', $icons), '</p>';
+    }
   }
 
 } // VF_Type

--- a/wp-content/themes/vf-wp/assets/assets/vfwp-admin/vfwp-admin.css
+++ b/wp-content/themes/vf-wp/assets/assets/vfwp-admin/vfwp-admin.css
@@ -219,6 +219,41 @@
   width: 10%;
 }
 
+.post-type-vf_block .edit-post-visual-editor,
+.post-type-vf_container .edit-post-visual-editor {
+  -ms-flex-preferred-size: auto;
+      flex-basis: auto;
+  -webkit-box-flex: 0;
+      -ms-flex-positive: 0;
+          flex-grow: 0;
+  -ms-flex-negative: 1;
+      flex-shrink: 1;
+}
+
+.post-type-vf_block .editor-block-list__layout,
+.post-type-vf_container .editor-block-list__layout {
+  min-height: 10px;
+}
+
+.post-type-vf_block .edit-post-layout__metaboxes,
+.post-type-vf_container .edit-post-layout__metaboxes {
+  -webkit-box-flex: 1;
+      -ms-flex-positive: 1;
+          flex-grow: 1;
+}
+
+.post-type-vf_block .edit-post-layout__metaboxes:empty,
+.post-type-vf_container .edit-post-layout__metaboxes:empty {
+  -webkit-box-flex: 0;
+      -ms-flex-positive: 0;
+          flex-grow: 0;
+}
+
+.post-type-vf_block .edit-post-layout__metaboxes .acf-hndle-cog,
+.post-type-vf_container .edit-post-layout__metaboxes .acf-hndle-cog {
+  display: none !important;
+}
+
 .editor-post-title__block {
   --vf-text-margin--bottom: 0;
 }

--- a/wp-content/themes/vf-wp/assets/assets/vfwp-admin/vfwp-admin.css
+++ b/wp-content/themes/vf-wp/assets/assets/vfwp-admin/vfwp-admin.css
@@ -169,6 +169,10 @@
  * Version: 0.0.1
  * Location: components/vfwp-admin
  */
+.vfwp-notice a {
+  text-decoration: none;
+}
+
 .has-extra-large-font-size {
   font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
   font-size: 32px;


### PR DESCRIPTION
Update the VF plugin blocks and containers edit screen to use the newer interface.

This will allow containers to use the `post_content` and Gutenberg editor to configure content (instead of ACF configuration).

![edit-screen](https://user-images.githubusercontent.com/998922/68394653-278c0080-0166-11ea-8771-e4da38d3f1f6.png)

The content editor is effectively hidden at the moment since no plugins use it.

Todo this PR:

- [x] disable editing of the `post_name` ("slug") which is still technically possible
- [x] update the `wp-list-table` with a meta column to show which plugins are ACF / Content Hub and which use the content editor

Future Ideas:

* Allow editors to create their own reusable containers based of templates (e.g. "EMBL News" grid layout) – Perhaps a different post type to separator from the global plugin containers.