### PR TITLE
update/vf-plugins

### DIFF
--- a/wp-content/plugins/vf-beta-container/index.php
+++ b/wp-content/plugins/vf-beta-container/index.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: VF-WP Beta
 Description: VF-WP theme global container.
-Version: 0.2.0
+Version: 0.2.1
 Author: EMBL-EBI Web Development
 Plugin URI: https://github.com/visual-framework/vf-wp
 Text Domain: vfwp

--- a/wp-content/plugins/vf-beta-container/index.php
+++ b/wp-content/plugins/vf-beta-container/index.php
@@ -16,6 +16,14 @@ require_once($path);
 
 class VF_Beta extends VF_Plugin {
 
+  protected $file = __FILE__;
+
+  protected $config = array(
+    'post_name'  => 'vf_beta',
+    'post_title' => 'Beta',
+    'post_type'  => 'vf_container',
+  );
+
   protected $API = array(
     'pattern'             => 'node-body',
     'filter-content-type' => 'article',
@@ -32,14 +40,7 @@ class VF_Beta extends VF_Plugin {
   }
 
   private function init() {
-    parent::initialize(
-      array(
-        'file'       => __FILE__,
-        'post_name'  => 'vf_beta',
-        'post_title' => 'Beta',
-        'post_type'  => 'vf_container'
-      )
-    );
+    parent::initialize();
 
     add_action(
       'vf/plugin/container/after_render/vf_global_header',
@@ -53,7 +54,7 @@ class VF_Beta extends VF_Plugin {
   }
 
   function api_url(array $query_vars = array()) {
-    $id = intval(get_field('vf_beta_node_id', $this->post->ID));
+    $id = intval(get_field('vf_beta_node_id', $this->post()->ID));
     $vars = array(
       'filter-id' => $id ? $id : 580
     );

--- a/wp-content/plugins/vf-breadcrumbs-container/index.php
+++ b/wp-content/plugins/vf-breadcrumbs-container/index.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: VF-WP Breadcrumbs
 Description: VF-WP theme global container.
-Version: 0.1.0
+Version: 0.1.1
 Author: EMBL-EBI Web Development
 Plugin URI: https://github.com/visual-framework/vf-wp
 Text Domain: vfwp

--- a/wp-content/plugins/vf-breadcrumbs-container/index.php
+++ b/wp-content/plugins/vf-breadcrumbs-container/index.php
@@ -16,22 +16,19 @@ require_once($path);
 
 class VF_Breadcrumbs extends VF_Plugin {
 
+  protected $file = __FILE__;
+
+  protected $config = array(
+    'post_name'  => 'vf_breadcrumbs',
+    'post_title' => 'Breadcrumbs',
+    'post_type'  => 'vf_container',
+  );
+
   function __construct(array $params = array()) {
     parent::__construct('vf_breadcrumbs');
     if (array_key_exists('init', $params)) {
-      $this->init();
+      parent::initialize();
     }
-  }
-
-  private function init() {
-    parent::initialize(
-      array(
-        'file'       => __FILE__,
-        'post_name'  => 'vf_breadcrumbs',
-        'post_title' => 'Breadcrumbs',
-        'post_type'  => 'vf_container'
-      )
-    );
   }
 
 } // VF_Breadcrumbs

--- a/wp-content/plugins/vf-data-resources-block/index.php
+++ b/wp-content/plugins/vf-data-resources-block/index.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: VF-WP Data resources
 Description: VF-WP theme block.
-Version: 0.1.2
+Version: 0.1.3
 Author: EMBL-EBI Web Development
 Plugin URI: https://github.com/visual-framework/vf-wp
 Text Domain: vfwp

--- a/wp-content/plugins/vf-data-resources-block/index.php
+++ b/wp-content/plugins/vf-data-resources-block/index.php
@@ -16,6 +16,13 @@ require_once($path);
 
 class VF_Data_resources extends VF_Plugin {
 
+  protected $file = __FILE__;
+
+  protected $config = array(
+    'post_name'  => 'vf_data_resources',
+    'post_title' => 'Data resources',
+  );
+
   protected $API = array(
     'pattern'             => 'vf-summary-image',
     'filter-content-type' => 'resource',
@@ -25,23 +32,13 @@ class VF_Data_resources extends VF_Plugin {
   function __construct(array $params = array()) {
     parent::__construct('vf_data_resources');
     if (array_key_exists('init', $params)) {
-      $this->init();
+      parent::initialize();
     }
   }
 
-  private function init() {
-    parent::initialize(
-      array(
-        'file'       => __FILE__,
-        'post_name'  => 'vf_data_resources',
-        'post_title' => 'Data resources'
-      )
-    );
-  }
-
   function api_url(array $query_vars = array()) {
-    $limit = intval(get_field('vf_data_resources_limit', $this->post->ID));
-    $order = get_field('vf_data_resources_order', $this->post->ID);
+    $limit = intval(get_field('vf_data_resources_limit', $this->post()->ID));
+    $order = get_field('vf_data_resources_order', $this->post()->ID);
 
     $vars = array(
       'limit' => $limit ? $limit : 30,

--- a/wp-content/plugins/vf-ebi-global-footer-container/index.php
+++ b/wp-content/plugins/vf-ebi-global-footer-container/index.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: VF-WP EBI VF 1.3 Global Footer
 Description: VF-WP theme global container.
-Version: 0.1.2
+Version: 0.1.3
 Author: EMBL-EBI Web Development
 Plugin URI: https://github.com/visual-framework/vf-wp
 Text Domain: vfwp
@@ -52,7 +52,7 @@ class VF_EBI_Global_Footer extends VF_Plugin {
       $classes[] = 'ebi-vf1-integration'; // enable the VF 1.x workarounds
       return $classes;
     }
-    
+
   }
 
   function api_url(array $query_vars = array()) {

--- a/wp-content/plugins/vf-ebi-global-footer-container/index.php
+++ b/wp-content/plugins/vf-ebi-global-footer-container/index.php
@@ -16,6 +16,14 @@ require_once($path);
 
 class VF_EBI_Global_Footer extends VF_Plugin {
 
+  protected $file = __FILE__;
+
+  protected $config = array(
+    'post_name'  => 'vf_ebi_global_footer',
+    'post_title' => 'EBI VF 1.3 Global Footer',
+    'post_type'  => 'vf_container',
+  );
+
   protected $API = array(
     'pattern'             => 'node-body',
     'filter-content-type' => 'article',
@@ -30,14 +38,7 @@ class VF_EBI_Global_Footer extends VF_Plugin {
   }
 
   private function init() {
-    parent::initialize(
-      array(
-        'file'       => __FILE__,
-        'post_name'  => 'vf_ebi_global_footer',
-        'post_title' => 'EBI VF 1.3 Global Footer',
-        'post_type'  => 'vf_container'
-      )
-    );
+    parent::initialize();
     add_action(
       'wp_enqueue_scripts',
       array($this, 'enqueue_assets'),
@@ -56,7 +57,7 @@ class VF_EBI_Global_Footer extends VF_Plugin {
   }
 
   function api_url(array $query_vars = array()) {
-    $id = intval(get_field('vf_ebi_global_footer_node_id', $this->post->ID));
+    $id = intval(get_field('vf_ebi_global_footer_node_id', $this->post()->ID));
     $vars = array(
       'filter-id' => $id ? $id : 6683
     );

--- a/wp-content/plugins/vf-ebi-global-header-container/index.php
+++ b/wp-content/plugins/vf-ebi-global-header-container/index.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: VF-WP EBI VF 1.3 Global Header
 Description: VF-WP theme global container.
-Version: 0.1.1
+Version: 0.1.2
 Author: EMBL-EBI Web Development
 Plugin URI: https://github.com/visual-framework/vf-wp
 Text Domain: vfwp

--- a/wp-content/plugins/vf-ebi-global-header-container/index.php
+++ b/wp-content/plugins/vf-ebi-global-header-container/index.php
@@ -16,6 +16,14 @@ require_once($path);
 
 class VF_EBI_Global_Header extends VF_Plugin {
 
+  protected $file = __FILE__;
+
+  protected $config = array(
+    'post_name'  => 'vf_ebi_global_header',
+    'post_title' => 'EBI VF 1.3 Global Header',
+    'post_type'  => 'vf_container',
+  );
+
   protected $API = array(
     'pattern'             => 'node-body',
     'filter-content-type' => 'article',
@@ -25,23 +33,12 @@ class VF_EBI_Global_Header extends VF_Plugin {
   public function __construct(array $params = array()) {
     parent::__construct('vf_ebi_global_header');
     if (array_key_exists('init', $params)) {
-      $this->init();
+      parent::initialize();
     }
   }
 
-  private function init() {
-    parent::initialize(
-      array(
-        'file'       => __FILE__,
-        'post_name'  => 'vf_ebi_global_header',
-        'post_title' => 'EBI VF 1.3 Global Header',
-        'post_type'  => 'vf_container'
-      )
-    );
-  }
-
   function api_url(array $query_vars = array()) {
-    $id = intval(get_field('vf_ebi_global_header_node_id', $this->post->ID));
+    $id = intval(get_field('vf_ebi_global_header_node_id', $this->post()->ID));
     $vars = array(
       'filter-id' => $id ? $id : 6682
     );

--- a/wp-content/plugins/vf-embl-news-container/index.php
+++ b/wp-content/plugins/vf-embl-news-container/index.php
@@ -16,10 +16,12 @@ require_once($path);
 
 class VF_EMBL_News extends VF_Plugin {
 
-  private $exists = array(
-    'field_display_title',
-    'field_teaser',
-    'field_canonical_location'
+  protected $file = __FILE__;
+
+  protected $config = array(
+    'post_name'  => 'vf_embl_news',
+    'post_title' => 'EMBL News',
+    'post_type'  => 'vf_container',
   );
 
   protected $API = array(
@@ -30,6 +32,12 @@ class VF_EMBL_News extends VF_Plugin {
     'source'                                 => 'contenthub',
   );
 
+  private $exists = array(
+    'field_display_title',
+    'field_teaser',
+    'field_canonical_location'
+  );
+
   function __construct(array $params = array()) {
     parent::__construct('vf_embl_news');
     if (array_key_exists('init', $params)) {
@@ -38,21 +46,13 @@ class VF_EMBL_News extends VF_Plugin {
   }
 
   private function init() {
-    parent::initialize(
-      array(
-        'file'       => __FILE__,
-        'post_name'  => 'vf_embl_news',
-        'post_title' => 'EMBL News',
-        'post_type'  => 'vf_container'
-      )
-    );
-
+    parent::initialize();
     add_action('init', array($this, 'add_taxonomy_fields'), 11);
   }
 
   function api_url(array $query_vars = array()) {
     $limit = intval(
-      get_field('vf_embl_news_limit', $this->post->ID)
+      get_field('vf_embl_news_limit', $this->post()->ID)
     );
 
     $vars = array(
@@ -64,7 +64,7 @@ class VF_EMBL_News extends VF_Plugin {
 
     // Use "Keyword" filter
     $keyword = vf_search_keyword(
-      get_field('vf_embl_news_keyword', $this->post->ID)
+      get_field('vf_embl_news_keyword', $this->post()->ID)
     );
     if ( ! empty($keyword)) {
       $vars[$filter_key] = $keyword;
@@ -73,7 +73,7 @@ class VF_EMBL_News extends VF_Plugin {
     // Prioritise "Term" filter
     if (function_exists('embl_taxonomy_get_term')) {
       $term = embl_taxonomy_get_term(
-        get_field('vf_embl_news_term', $this->post->ID)
+        get_field('vf_embl_news_term', $this->post()->ID)
       );
       if ($term && array_key_exists(EMBL_Taxonomy::META_NAME, $term->meta)) {
         $vars[$filter_key] = $term->meta[EMBL_Taxonomy::META_NAME];

--- a/wp-content/plugins/vf-embl-news-container/index.php
+++ b/wp-content/plugins/vf-embl-news-container/index.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: VF-WP EMBL News
 Description: VF-WP theme global container.
-Version: 0.1.1
+Version: 0.1.2
 Author: EMBL-EBI Web Development
 Plugin URI: https://github.com/visual-framework/vf-wp
 Text Domain: vfwp

--- a/wp-content/plugins/vf-example-block/index.php
+++ b/wp-content/plugins/vf-example-block/index.php
@@ -26,10 +26,16 @@ require_once($path);
  */
 class VF_Example extends VF_Plugin {
 
+  protected $file = __FILE__;
+
+  protected $config = array(
+    'post_name'  => 'vf_example',
+    'post_title' => 'Example',
+  );
+
   public function __construct(array $params = array()) {
     /**
      * Parent constructor sets up local variables.
-     * Importantly: `$this->post` (or `$plugin->post()` outside)
      */
     parent::__construct('vf_example');
 
@@ -43,13 +49,7 @@ class VF_Example extends VF_Plugin {
      * Initialize to add plugin registration hooks.
      * The related `vf_block` or `vf_container` post is created (or updated.)
      */
-    parent::initialize(
-      array(
-        'file'       => __FILE__,
-        'post_name'  => 'vf_example',
-        'post_title' => 'Example'
-      )
-    );
+    parent::initialize();
 
     /**
      * Add ACF filter hook to dynamically populate a select field

--- a/wp-content/plugins/vf-example-block/index.php
+++ b/wp-content/plugins/vf-example-block/index.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: VF-WP Example
 Description: VF-WP theme block (developer example).
-Version: 0.1.0
+Version: 0.1.1
 Author: EMBL-EBI Web Development
 Plugin URI: https://github.com/visual-framework/vf-wp
 Text Domain: vfwp

--- a/wp-content/plugins/vf-factoid-block/index.php
+++ b/wp-content/plugins/vf-factoid-block/index.php
@@ -18,6 +18,13 @@ require_once('widget.php');
 
 class VF_Factoid extends VF_Plugin {
 
+  protected $file = __FILE__;
+
+  protected $config = array(
+    'post_name'  => 'vf_factoid',
+    'post_title' => 'Factoid',
+  );
+
   protected $API = array(
     'pattern'             => 'vf-factoid',
     'filter-content-type' => 'factoid',
@@ -32,21 +39,14 @@ class VF_Factoid extends VF_Plugin {
   }
 
   private function init() {
-    parent::initialize(
-      array(
-        'file'       => __FILE__,
-        'post_name'  => 'vf_factoid',
-        'post_title' => 'Factoid'
-      )
-    );
-
+    parent::initialize();
     add_action('widgets_init', array($this, 'widgets_init'));
   }
 
   public function api_url(array $query_vars = array()) {
 
-    $limit = intval(get_field('vf_factoid_limit', $this->post->ID));
-    $id = trim(get_field('vf_factoid_id', $this->post->ID));
+    $limit = intval(get_field('vf_factoid_limit', $this->post()->ID));
+    $id = trim(get_field('vf_factoid_id', $this->post()->ID));
 
     // Required vars
     $vars = array(

--- a/wp-content/plugins/vf-factoid-block/index.php
+++ b/wp-content/plugins/vf-factoid-block/index.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: VF-WP Factoid
 Description: VF-WP theme block.
-Version: 0.1.1
+Version: 0.1.2
 Author: EMBL-EBI Web Development
 Plugin URI: https://github.com/visual-framework/vf-wp
 Text Domain: vfwp

--- a/wp-content/plugins/vf-global-footer-container/index.php
+++ b/wp-content/plugins/vf-global-footer-container/index.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: VF-WP Global Footer
 Description: VF-WP theme global container.
-Version: 0.1.1
+Version: 0.1.2
 Author: EMBL-EBI Web Development
 Plugin URI: https://github.com/visual-framework/vf-wp
 Text Domain: vfwp

--- a/wp-content/plugins/vf-global-footer-container/index.php
+++ b/wp-content/plugins/vf-global-footer-container/index.php
@@ -16,6 +16,14 @@ require_once($path);
 
 class VF_Global_Footer extends VF_Plugin {
 
+  protected $file = __FILE__;
+
+  protected $config = array(
+    'post_name'  => 'vf_global_footer',
+    'post_title' => 'Global Footer',
+    'post_type'  => 'vf_container',
+  );
+
   protected $API = array(
     'pattern'             => 'node-body',
     'filter-content-type' => 'article',
@@ -25,23 +33,12 @@ class VF_Global_Footer extends VF_Plugin {
   function __construct(array $params = array()) {
     parent::__construct('vf_global_footer');
     if (array_key_exists('init', $params)) {
-      $this->init();
+      parent::initialize();
     }
   }
 
-  private function init() {
-    parent::initialize(
-      array(
-        'file'       => __FILE__,
-        'post_name'  => 'vf_global_footer',
-        'post_title' => 'Global Footer',
-        'post_type'  => 'vf_container'
-      )
-    );
-  }
-
   function api_url(array $query_vars = array()) {
-    $id = intval(get_field('vf_global_footer_node_id', $this->post->ID));
+    $id = intval(get_field('vf_global_footer_node_id', $this->post()->ID));
     $vars = array(
       'filter-id' => $id ? $id : 569
     );

--- a/wp-content/plugins/vf-global-header-container/index.php
+++ b/wp-content/plugins/vf-global-header-container/index.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: VF-WP Global Header
 Description: VF-WP theme global container.
-Version: 0.1.1
+Version: 0.1.2
 Author: EMBL-EBI Web Development
 Plugin URI: https://github.com/visual-framework/vf-wp
 Text Domain: vfwp

--- a/wp-content/plugins/vf-global-header-container/index.php
+++ b/wp-content/plugins/vf-global-header-container/index.php
@@ -16,6 +16,14 @@ require_once($path);
 
 class VF_Global_Header extends VF_Plugin {
 
+  protected $file = __FILE__;
+
+  protected $config = array(
+    'post_name'  => 'vf_global_header',
+    'post_title' => 'Global Header',
+    'post_type'  => 'vf_container',
+  );
+
   protected $API = array(
     'pattern'             => 'node-body',
     'filter-content-type' => 'article',
@@ -25,23 +33,12 @@ class VF_Global_Header extends VF_Plugin {
   public function __construct(array $params = array()) {
     parent::__construct('vf_global_header');
     if (array_key_exists('init', $params)) {
-      $this->init();
+      parent::initialize();
     }
   }
 
-  private function init() {
-    parent::initialize(
-      array(
-        'file'       => __FILE__,
-        'post_name'  => 'vf_global_header',
-        'post_title' => 'Global Header',
-        'post_type'  => 'vf_container'
-      )
-    );
-  }
-
   function api_url(array $query_vars = array()) {
-    $id = intval(get_field('vf_global_header_node_id', $this->post->ID));
+    $id = intval(get_field('vf_global_header_node_id', $this->post()->ID));
     $vars = array(
       'filter-id' => $id ? $id : 574
     );

--- a/wp-content/plugins/vf-group-header-block/index.php
+++ b/wp-content/plugins/vf-group-header-block/index.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: VF-WP Group Header
 Description: VF-WP theme block.
-Version: 0.1.2
+Version: 0.1.3
 Author: EMBL-EBI Web Development
 Plugin URI: https://github.com/visual-framework/vf-wp
 Text Domain: vfwp

--- a/wp-content/plugins/vf-group-header-block/index.php
+++ b/wp-content/plugins/vf-group-header-block/index.php
@@ -16,6 +16,13 @@ require_once($path);
 
 class VF_Group_Header extends VF_Plugin {
 
+  protected $file = __FILE__;
+
+  protected $config = array(
+    'post_name'  => 'vf_group_header',
+    'post_title' => 'Group Header',
+  );
+
   private $is_minimal = false;
 
   protected $API = array(
@@ -33,20 +40,13 @@ class VF_Group_Header extends VF_Plugin {
     }
   }
 
-  function is_minimal() {
-    return $this->is_minimal;
+  private function init() {
+    parent::initialize();
+    add_action('admin_head', array($this, 'admin_head'), 15);
   }
 
-  private function init() {
-    parent::initialize(
-      array(
-        'file'       => __FILE__,
-        'post_name'  => 'vf_group_header',
-        'post_title' => 'Group Header'
-      )
-    );
-
-    add_action('admin_head', array($this, 'admin_head'), 15);
+  function is_minimal() {
+    return $this->is_minimal;
   }
 
   function api_url(array $query_vars = array()) {
@@ -76,7 +76,7 @@ class VF_Group_Header extends VF_Plugin {
   }
 
   function heading_html() {
-    $heading = get_field('vf_group_header_heading', $this->post->ID);
+    $heading = get_field('vf_group_header_heading', $this->post()->ID);
     $heading = esc_html($heading);
     $heading = trim($heading);
     $heading = "<h1 class=\"vf-lede\">{$heading}</h1>";

--- a/wp-content/plugins/vf-gutenberg/vf-gutenberg.php
+++ b/wp-content/plugins/vf-gutenberg/vf-gutenberg.php
@@ -406,11 +406,11 @@ class VF_Gutenberg {
     if ( ! class_exists('VF_Plugin')) {
       return $config;
     }
-    $plugins = VF_Plugin::get_config();
-    if (empty($plugins)) {
+    global $vf_plugins;
+    if (empty($vf_plugins)) {
       return $config;
     }
-    foreach ($plugins as $post_name => $value) {
+    foreach ($vf_plugins as $post_name => $value) {
       $plugin = VF_Plugin::get_plugin($post_name);
       if ( ! $plugin->is_block()) {
         continue;

--- a/wp-content/plugins/vf-jobs-block/index.php
+++ b/wp-content/plugins/vf-jobs-block/index.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: VF-WP Jobs
 Description: VF-WP theme block.
-Version: 0.1.2
+Version: 0.1.3
 Author: EMBL-EBI Web Development
 Plugin URI: https://github.com/visual-framework/vf-wp
 Text Domain: vfwp

--- a/wp-content/plugins/vf-jobs-block/index.php
+++ b/wp-content/plugins/vf-jobs-block/index.php
@@ -16,6 +16,13 @@ require_once($path);
 
 class VF_Jobs extends VF_Plugin {
 
+  protected $file = __FILE__;
+
+  protected $config = array(
+    'post_name'  => 'vf_jobs',
+    'post_title' => 'Jobs',
+  );
+
   private $term_who;
   private $term_what;
   private $term_where;
@@ -34,19 +41,12 @@ class VF_Jobs extends VF_Plugin {
   }
 
   private function init() {
-    parent::initialize(
-      array(
-        'file'       => __FILE__,
-        'post_name'  => 'vf_jobs',
-        'post_title' => 'Jobs'
-      )
-    );
-
+    parent::initialize();
     add_action('init', array($this, 'add_taxonomy_fields'), 11);
   }
 
   function api_url(array $query_vars = array()) {
-    $limit = intval(get_field('vf_jobs_limit', $this->post->ID));
+    $limit = intval(get_field('vf_jobs_limit', $this->post()->ID));
 
     $vars = array(
       'limit' => $limit ? $limit : 10
@@ -65,7 +65,7 @@ class VF_Jobs extends VF_Plugin {
     // Otherwise use defaults
     } else if (function_exists('embl_taxonomy')) {
       $term = null;
-      $filter = get_field('vf_jobs_filter', $this->post->ID);
+      $filter = get_field('vf_jobs_filter', $this->post()->ID);
       switch ( $filter ) {
         case 'cluster':
           $term = $this->get_term('what');
@@ -84,7 +84,7 @@ class VF_Jobs extends VF_Plugin {
           $filter_key = 'filter-field-contains[field_jobs_duty_station]';
           break;
         case 'term':
-          $term = get_field('vf_jobs_term', $this->post->ID);
+          $term = get_field('vf_jobs_term', $this->post()->ID);
           $term = intval($term);
           if (is_int($term)) {
             $term = embl_taxonomy_get_term($term);

--- a/wp-content/plugins/vf-latest-posts-block/index.php
+++ b/wp-content/plugins/vf-latest-posts-block/index.php
@@ -16,6 +16,13 @@ require_once($path);
 
 class VF_Latest_Posts extends VF_Plugin {
 
+  protected $file = __FILE__;
+
+  protected $config = array(
+    'post_name'  => 'vf_latest_posts',
+    'post_title' => 'Latest Posts',
+  );
+
   public function __construct(array $params = array()) {
     parent::__construct('vf_latest_posts');
     if (array_key_exists('init', $params)) {
@@ -24,14 +31,7 @@ class VF_Latest_Posts extends VF_Plugin {
   }
 
   private function init() {
-    parent::initialize(
-      array(
-        'file'       => __FILE__,
-        'post_name'  => 'vf_latest_posts',
-        'post_title' => 'Latest Posts'
-      )
-    );
-
+    parent::initialize();
     add_action('admin_head', array($this, 'admin_head'), 15);
   }
 

--- a/wp-content/plugins/vf-latest-posts-block/index.php
+++ b/wp-content/plugins/vf-latest-posts-block/index.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: VF-WP Latest Posts
 Description: VF-WP theme block.
-Version: 0.1.1
+Version: 0.1.2
 Author: EMBL-EBI Web Development
 Plugin URI: https://github.com/visual-framework/vf-wp
 Text Domain: vfwp

--- a/wp-content/plugins/vf-members-block/index.php
+++ b/wp-content/plugins/vf-members-block/index.php
@@ -16,6 +16,13 @@ require_once($path);
 
 class VF_Members extends VF_Plugin {
 
+  protected $file = __FILE__;
+
+  protected $config = array(
+    'post_name'  => 'vf_members',
+    'post_title' => 'Members',
+  );
+
   protected $API = array(
     'pattern'             => 'vf-summary-profile-l',
     'filter-content-type' => 'person',
@@ -25,23 +32,13 @@ class VF_Members extends VF_Plugin {
   function __construct(array $params = array()) {
     parent::__construct('vf_members');
     if (array_key_exists('init', $params)) {
-      $this->init();
+      parent::initialize();
     }
   }
 
-  private function init() {
-    parent::initialize(
-      array(
-        'file'       => __FILE__,
-        'post_name'  => 'vf_members',
-        'post_title' => 'Members'
-      )
-    );
-  }
-
   function api_url(array $query_vars = array()) {
-    $limit = intval(get_field('vf_members_limit', $this->post->ID));
-    $order = get_field('vf_members_order', $this->post->ID);
+    $limit = intval(get_field('vf_members_limit', $this->post()->ID));
+    $order = get_field('vf_members_order', $this->post()->ID);
 
     $vars = array(
       'limit' => $limit ? $limit : 30,

--- a/wp-content/plugins/vf-members-block/index.php
+++ b/wp-content/plugins/vf-members-block/index.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: VF-WP Members
 Description: VF-WP theme block.
-Version: 0.1.2
+Version: 0.1.3
 Author: EMBL-EBI Web Development
 Plugin URI: https://github.com/visual-framework/vf-wp
 Text Domain: vfwp

--- a/wp-content/plugins/vf-publications-block/index.php
+++ b/wp-content/plugins/vf-publications-block/index.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: VF-WP Publications
 Description: VF-WP theme block.
-Version: 0.1.2
+Version: 0.1.3
 Author: EMBL-EBI Web Development
 Plugin URI: https://github.com/visual-framework/vf-wp
 Text Domain: vfwp

--- a/wp-content/plugins/vf-publications-block/index.php
+++ b/wp-content/plugins/vf-publications-block/index.php
@@ -16,6 +16,13 @@ require_once($path);
 
 class VF_Publications extends VF_Plugin {
 
+  protected $file = __FILE__;
+
+  protected $config = array(
+    'post_name'  => 'vf_publications',
+    'post_title' => 'Team publications',
+  );
+
   protected $API = array(
     'source' => 'contenthub',
   );
@@ -23,19 +30,8 @@ class VF_Publications extends VF_Plugin {
   public function __construct(array $params = array()) {
     parent::__construct('vf_publications');
     if (array_key_exists('init', $params)) {
-      $this->init();
+      parent::initialize();
     }
-  }
-
-  // the site-wide default
-  private function init() {
-    parent::initialize(
-      array(
-        'file'       => __FILE__,
-        'post_name'  => 'vf_publications',
-        'post_title' => 'Team publications'
-      )
-    );
   }
 
   // Query the contentHub API, samples:
@@ -43,12 +39,12 @@ class VF_Publications extends VF_Plugin {
   //   - ORCID: https://dev.content.embl.org/api/v1/pattern.html?pattern=embl-person-publications&orcid=0000-0001-5454-2815
   //   - Name: https://dev.content.embl.org/api/v1/pattern.html?pattern=embl-person-publications&title=Maria-Jesus
   function api_url(array $query_vars = array()) {
-    $limit = intval(get_field('vf_publications_limit', $this->post->ID));
-    $order = get_field('vf_publications_order', $this->post->ID);
+    $limit = intval(get_field('vf_publications_limit', $this->post()->ID));
+    $order = get_field('vf_publications_order', $this->post()->ID);
 
     // load
-    $searchType = get_field('vf_publications_type', $this->post->ID) ?? 'team';
-    $searchQuery = get_field('vf_publications_query', $this->post->ID);
+    $searchType = get_field('vf_publications_type', $this->post()->ID) ?? 'team';
+    $searchQuery = get_field('vf_publications_query', $this->post()->ID);
 
     if ($searchType == 'team' || $searchType == 'person_name') {
       $queryKey = 'title';

--- a/wp-content/plugins/vf-publications-group-ebi-block/index.php
+++ b/wp-content/plugins/vf-publications-group-ebi-block/index.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: VF-WP Publications Group EBI
 Description: Query for team publications based of EMBL-EBI specific data source (EBI Content Database).
-Version: 0.1.2
+Version: 0.1.3
 Author: EMBL-EBI Web Development
 Plugin URI: https://github.com/visual-framework/vf-wp
 Text Domain: vfwp

--- a/wp-content/plugins/vf-publications-group-ebi-block/index.php
+++ b/wp-content/plugins/vf-publications-group-ebi-block/index.php
@@ -16,6 +16,13 @@ require_once($path);
 
 class VF_Publications_group_ebi extends VF_Plugin {
 
+  protected $file = __FILE__;
+
+  protected $config = array(
+    'post_name'  => 'vf_publications_group_ebi',
+    'post_title' => 'EBI Team publications',
+  );
+
   protected $API = array(
     'pattern'             => 'ebi-team-publications',
     'source'              => 'contenthub',
@@ -25,25 +32,15 @@ class VF_Publications_group_ebi extends VF_Plugin {
   public function __construct(array $params = array()) {
     parent::__construct('vf_publications_group_ebi');
     if (array_key_exists('init', $params)) {
-      $this->init();
+      parent::initialize();
     }
-  }
-
-  private function init() {
-    parent::initialize(
-      array(
-        'file'       => __FILE__,
-        'post_name'  => 'vf_publications_group_ebi',
-        'post_title' => 'EBI Team publications'
-      )
-    );
   }
 
   // Query the contentHub API, samples:
   //   - Group: https://dev.content.embl.org/api/v1/pattern.html?pattern=ebi-team-publications&title=Web%20Development
   function api_url(array $query_vars = array()) {
-    $limit = intval(get_field('vf_publications_group_ebi_limit', $this->post->ID));
-    $order = get_field('vf_publications_group_ebi_order', $this->post->ID);
+    $limit = intval(get_field('vf_publications_group_ebi_limit', $this->post()->ID));
+    $order = get_field('vf_publications_group_ebi_order', $this->post()->ID);
 
     $vars = array(
       'limit' => $limit ? $limit : 30,

--- a/wp-content/plugins/vf-wp/README.md
+++ b/wp-content/plugins/vf-wp/README.md
@@ -36,40 +36,11 @@ The `VF_Plugin` class is extended by all Block and Container plugins.
 
 It provides common methods to:
 
-* Register the plugin in the global option
+* Register and initialise the plugin
 * Insert the custom post for the plugin
 * Load custom ACF config from the plugin directory
 * Return the template path from the plugin directory
 * Render a plugin template (static method)
-
-### The `vf__plugins` option
-
-This option is set in the `wp_options` database table to keep track of all activated VF plugins and to help resolve template paths. It is automatically managed by `VF_Plugin` as they are activated or deactivated.
-
-The value is a serialized PHP array that follows this format:
-
-```php
-array (
-  'vf_page_template' =>
-  array (
-    'post_type' => 'vf_container',
-  ),
-  'vf_breadcrumbs' =>
-  array (
-    'post_type'       => 'vf_container',
-    'class'           => 'VF_Breadcrumbs',
-    'plugin__dirname' => 'vf-breadcrumbs-container',
-  ),
-  'vf_jobs' =>
-  array (
-    'post_type'       => 'vf_block',
-    'class'           => 'VF_Jobs',
-    'plugin__dirname' => 'vf-jobs-block',
-  )
-)
-```
-
-The array keys, such as `vf_breadcrumbs`, are the `post_name` of the Block or Container. **Because of this all `vf_block` and `vf_container` plugins should have a unique `post_name` despite being two different post types**.
 
 ## Plugin ACF configuration
 

--- a/wp-content/plugins/vf-wp/vf-plugin.php
+++ b/wp-content/plugins/vf-wp/vf-plugin.php
@@ -9,122 +9,58 @@ if ( ! class_exists('VF_Plugin') ) :
  */
 class VF_Plugin {
 
-  // Saved config for plugin activation
-  private $config;
-  // `WP_Post` of custom post type (`vf_container` or `vf_block`)
-  protected $post;
   // Plugin file path to index.php extending this class
   protected $file;
+  // Saved config for plugin activation
+  protected $config;
   // Plugin contentHub API settings
   protected $API;
 
-  /**
-   * `post_name` is used as the unique plugin ID
-   */
-  public function __construct($post_name = false) {
-    if ( ! is_string($post_name)) {
-      return;
-    }
-    $this->setup($post_name);
-  }
+  // `WP_Post` of custom post type (e.g. `vf_block`)
+  private $post;
 
-  /**
-   * Setup the plugin instance based on the `post_name` (plugin ID)
-   */
-  protected function setup($post_name) {
-    // Get plugin config
-    $config = VF_Plugin::get_config($post_name);
-    if ( ! is_array($config) || ! array_key_exists('post_type', $config)) {
-      return;
-    }
-
-    // Setup plugin post based on config
-    $this->post = get_page_by_path($post_name, OBJECT, $config['post_type']);
-
-    // Setup plugin file based on config
-    if (array_key_exists('plugin__dirname', $config)) {
-      $file = WP_PLUGIN_DIR . "/{$config['plugin__dirname']}/index.php";
-      if (file_exists($file)) {
-        $this->file = $file;
-      }
+  public function __construct() {
+    // Setup configuration
+    $this->config['file'] = $this->file;
+    $this->config['class'] = get_class($this);
+    // Setup defaults
+    if ( ! array_key_exists('post_type', $this->config)) {
+      $this->config['post_type'] = 'vf_block';
     }
   }
 
   /**
    * Initialize a new plugin that is extending this class
    */
-  protected function initialize($config = array()) {
-    if ( ! is_array($config)) {
-      return;
-    }
-    // Cannot initialize base plugin class
-    $config['class'] = get_class($this);
-    if ($config['class'] === 'VF_Plugin') {
-      return;
-    }
-    // Plugins extending this class must provide __FILE__
-    if ( ! array_key_exists('file', $config) ||
-         ! file_exists($config['file'])) {
-      return;
-    }
-    // `post_type` is required (set default)
-    if ( ! array_key_exists('post_type', $config)) {
-      $config['post_type'] = 'vf_block';
-    }
-
-    // Save config for action hooks
-    $this->config = $config;
-
-    // Auto activate
-    if (
-      isset($config['activate']) &&
-      $config['activate'] === true
-    ) {
-      if ( ! $this->post()) {
-        $this->activation_hook();
-      }
-      $this->plugins_loaded();
-      return;
-    }
-
-    // Register WP hooks
-    register_activation_hook(
-      $config['file'],
-      array($this, 'activation_hook')
-    );
-    register_deactivation_hook(
-      $config['file'],
-      array($this, 'deactivation_hook')
-    );
-    add_action(
-      'plugins_loaded',
-      array($this, 'plugins_loaded')
-    );
-  }
-
-  public function activation_hook() {
-    if (is_array($this->config)) {
-      VF_Plugin::register($this->config);
-    }
-  }
-
-  public function deactivation_hook() {
-    if (is_array($this->config)) {
-      VF_Plugin::deregister($this->config);
-    }
-  }
-
-  /**
-   * Action: setup private vars and hooks after the plugin has initialized
-   */
-  public function plugins_loaded() {
+  protected function initialize() {
     if ( ! is_array($this->config)) {
       return;
     }
-    $this->setup($this->config['post_name']);
-    if ( ! $this->post instanceof WP_Post) {
-      return;
+    // Add to global register
+    global $vf_plugins;
+    if ( ! is_array($vf_plugins)) {
+      $vf_plugins = array();
     }
+    $vf_plugins[$this->config['post_name']] = $this->config;
+
+    // "Activate" immediately if loaded via theme directory
+    if ($this->is_theme()) {
+      if ( ! $this->post()) {
+        $this->activation_hook();
+      }
+    }
+    // Register WP hooks for plugin directory
+    if ($this->is_plugin()) {
+      register_activation_hook(
+        $this->file,
+        array($this, 'activation_hook')
+      );
+      register_deactivation_hook(
+        $this->file,
+        array($this, 'deactivation_hook')
+      );
+    }
+    // Add ACF JSON locations
     if ($this->is_acf()) {
       add_filter(
         'acf/settings/load_json',
@@ -138,32 +74,37 @@ class VF_Plugin {
     }
   }
 
+  public function activation_hook() {
+    VF_Plugin::register($this->config);
+  }
+
+  public function deactivation_hook() {
+    VF_Plugin::deregister($this->config);
+  }
+
   /**
    * Return plugin post
    */
   public function post() {
-    if ($this->post instanceof WP_Post) {
-      return $this->post;
-    }
-    return null;
-  }
-
-  /**
-   * Return plugin post type
-   */
-  public function type() {
     if ( ! $this->post instanceof WP_Post) {
-      return;
+      $this->post = get_page_by_path(
+        $this->config['post_name'],
+        OBJECT,
+        $this->config['post_type']
+      );
     }
-    return $this->post->post_type;
+    if ( ! $this->post instanceof WP_Post) {
+      $this->post = null;
+    }
+    return $this->post;
   }
 
   public function is_block() {
-    return $this->type() === 'vf_block';
+    return $this->config['post_type'] === 'vf_block';
   }
 
   public function is_container() {
-    return $this->type() === 'vf_container';
+    return $this->config['post_type'] === 'vf_container';
   }
 
   /**
@@ -184,7 +125,7 @@ class VF_Plugin {
    * Return true if plugin has ACF configuration
    */
   public function is_acf() {
-    $path = "{$this->dir()}group_{$this->post->post_name}.json";
+    $path = "{$this->dir()}group_{$this->config['post_name']}.json";
     return file_exists($path);
   }
 
@@ -258,29 +199,22 @@ class VF_Plugin {
   }
 
   /**
-   * Return a plugin from the global option if registered
+   * Return a plugin from the global register
    */
-  static public function get_config($post_name = null) {
-    $plugins = unserialize(get_option('vf__plugins'));
-    if ( ! is_array($plugins)) {
-      return;
+  static public function get_config($post_name = '') {
+    global $vf_plugins;
+    if ( ! is_array($vf_plugins)) {
+      $vf_plugins = array();
     }
-    if ( ! $post_name) {
-      return $plugins;
+    if (array_key_exists($post_name, $vf_plugins)) {
+      return $vf_plugins[$post_name];
     }
-    if ( ! array_key_exists($post_name, $plugins)) {
-      return;
-    }
-    return $plugins[$post_name];
   }
 
   /**
    * Return new plugin class instance from `post_name`
    */
   static public function get_plugin($post_name) {
-    if (empty($post_name)) {
-      return;
-    }
     $config = VF_Plugin::get_config($post_name);
     if ( ! is_array($config)) {
       return;
@@ -306,21 +240,20 @@ class VF_Plugin {
     if ( ! is_array($config)) {
       return;
     }
-    // `post_name` is required
-    if ( ! array_key_exists('post_name', $config)) {
+    // required keys
+    if (array_diff(
+      array('post_name', 'post_title', 'post_type'),
+      array_keys($config)
+    )) {
       return;
-    }
-    // `post_title` is required
-    if ( ! array_key_exists('post_title', $config)) {
-      return;
-    }
-    // `post_type` is required (set default)
-    if ( ! array_key_exists('post_type', $config)) {
-      $config['post_type'] = 'vf_block';
     }
     // Add plugin post if it does not exist
-    $plugin = get_page_by_path($config['post_name'], OBJECT, $config['post_type']);
-    if ( ! $plugin) {
+    $plugin = get_page_by_path(
+      $config['post_name'],
+      OBJECT,
+      $config['post_type']
+    );
+    if ( ! $plugin instanceof WP_Post) {
       $plugin = get_post(
           wp_insert_post(array(
           'post_author' => 1,
@@ -339,43 +272,18 @@ class VF_Plugin {
         'post_status' => 'publish'
       ));
     }
-    // Get plugins option and save new plugin data
-    $plugins = unserialize(get_option('vf__plugins'));
-    if ( ! is_array($plugins)) {
-      $plugins = array();
-    }
-    $plugins[$config['post_name']] = array(
-      'post_type' => $config['post_type']
-    );
-    // Save plugin class to option
-    if (array_key_exists('class', $config) && is_string($config['class'])) {
-      $plugins[$config['post_name']]['class'] = $config['class'];
-    }
-    // Save plugin directory name to option
-    if (array_key_exists('file', $config) && file_exists($config['file'])) {
-      $plugins[$config['post_name']]['plugin__dirname'] = basename(dirname($config['file']));
-    }
-    update_option('vf__plugins', serialize($plugins));
   }
 
   /**
    * Remove plugin data from the global option
    */
   static public function deregister($config) {
-    // Get plugins option
-    $plugins = unserialize(get_option('vf__plugins'));
-    // Validate option
-    if ( ! is_array($plugins)) {
-      return;
-    }
-    if ( ! array_key_exists($config['post_name'], $plugins)) {
-      return;
-    }
-    // Remove plugin and save option
-    unset($plugins[$config['post_name']]);
-    update_option('vf__plugins', serialize($plugins));
     // Get plugin post and set to draft (do not delete)
-    $plugin = get_page_by_path($config['post_name'], OBJECT, $config['post_type']);
+    $plugin = get_page_by_path(
+      $config['post_name'],
+      OBJECT,
+      $config['post_type']
+    );
     if ($plugin instanceof WP_Post) {
       wp_update_post(array(
         'ID'          => $plugin->ID,
@@ -494,7 +402,7 @@ class VF_Plugin {
    */
   public function acf_update_field_group($group) {
     if ($this->dir()) {
-      if ($group['key'] === "group_{$this->post->post_name}") {
+      if ($group['key'] === "group_{$this->config['post_name']}") {
         update_option('vf__acf_save_json', $this->dir());
       }
     }

--- a/wp-content/themes/vf-wp-groups/vf-wp-groups-header/index.php
+++ b/wp-content/themes/vf-wp-groups/vf-wp-groups-header/index.php
@@ -16,26 +16,19 @@ require_once($path);
 
 class VF_WP_Groups_Header extends VF_Plugin {
 
-  private $post_name = 'vf_wp_groups_header';
   protected $file = __FILE__;
 
+  protected $config = array(
+    'post_name'  => 'vf_wp_groups_header',
+    'post_title' => 'Groups Header',
+    'post_type'  => 'vf_container',
+  );
+
   function __construct(array $params = array()) {
-    parent::__construct($this->post_name);
+    parent::__construct();
     if (array_key_exists('init', $params)) {
-      $this->init();
+      parent::initialize();
     }
-  }
-
-  private function init() {
-
-    parent::initialize(
-      array(
-        'post_name'  => $this->post_name,
-        'post_title' => 'Groups Header',
-        'post_type'  => 'vf_container',
-        'activate'   => true
-      )
-    );
   }
 
 } // VF_WP_Groups_Header


### PR DESCRIPTION
This PR simplifies the VF-WP plugin setup.

It removes the necessity for a `vf__plugins` database option. Instead all active plugins are in the global `$vf_plugins` array.

This makes it easier to load blocks/containers from the theme directory.