### PR TITLE
chore: point-to-prod-contenthub

### DIFF
--- a/docs/wordpress.md
+++ b/docs/wordpress.md
@@ -47,7 +47,7 @@ https://dev.assets.emblstatic.net/vf/v2.0.0-beta.3/scripts/scripts.js
 EMBL ContentHub API:
 
 ```
-https://dev.beta.embl.org/api/v1/
+https://www.embl.org/api/v1/
 ```
 
 * Add and activate **ACF Pro** (Advanced Custom Fields) plugin

--- a/wp-content/plugins/embl-taxonomy/README.md
+++ b/wp-content/plugins/embl-taxonomy/README.md
@@ -153,7 +153,7 @@ The `TERM_ID` refers to the `wp_terms` table primary key.
 `options_embl_taxonomy` is the URL for the EMBL Taxonomy JSON feed. For example:
 
 ```
-https://dev.beta.embl.org/api/v1/pattern.json?pattern=embl-ontology&source=contenthub
+https://www.embl.org/api/v1/pattern.json?pattern=embl-ontology&source=contenthub
 ```
 
 If the three term options are set meta tags will be outputted in the `<head>`.

--- a/wp-content/plugins/embl-taxonomy/includes/settings.php
+++ b/wp-content/plugins/embl-taxonomy/includes/settings.php
@@ -10,7 +10,7 @@ if ( ! class_exists('EMBL_Taxonomy_Settings') ) :
 class EMBL_Taxonomy_Settings {
 
   private $defaults = array(
-    'embl_taxonomy' => 'https://dev.beta.embl.org/api/v1/pattern.json?pattern=embl-ontology&source=contenthub'
+    'embl_taxonomy' => 'https://wwww.embl.org/api/v1/pattern.json?pattern=embl-ontology&source=contenthub'
   );
 
   private $props = array(


### PR DESCRIPTION
We now have a production contentHub and should use it, except when testing features of the dev contentHub