### PR TITLE
Bug: overflow issue when using vf-u-fullbleed on an component with vf-grid

### DIFF
--- a/wp-content/themes/vf-wp-news/partials/newsletter-container.php
+++ b/wp-content/themes/vf-wp-news/partials/newsletter-container.php
@@ -1,6 +1,6 @@
-<div class="vf-grid | vf-u-background-color--grey--dark | vf-u-text-color--ui--white | vf-u-fullbleed | newsletter-container"
+<div class="embl-grid | vf-u-background-color--grey--dark | vf-u-text-color--ui--white | vf-u-fullbleed | newsletter-container"
   style="--page-grid-gap: 0;">
-  <div class="vf-u-background-color--grey--dark| vf-u-padding--md">
+  <div class="vf-u-padding--md">
     <h3 class="vf-text vf-text-heading--4 | newsletter-title">Subscribe to our monthly e-newsletter</h3>
     <?php echo do_shortcode('[mc4wp_form id="7843"]') ?>
     <!-- <form action="" class="vf-form">
@@ -13,19 +13,19 @@
       </div>
     </form> -->
   </div>
-  <div class="vf-u-background-color--grey--dark | vf-u-padding--md">
+  <div class="vf-u-padding--md">
     <h3 class="vf-text vf-text-heading--4">Newsletter Archive</h3>
     <a href="https://us19.campaign-archive.com/home/?u=0e036bd015172d9634dbdba98&id=35e7ef8d6f"
       class="vf-link press-link" style="color: white;">Read past editions of our monthly e-newsletter</a>
   </div>
-  <div class="vf-u-background-color--grey--dark | vf-u-padding--md">
+  <div class="vf-u-padding--md">
     <h3 class="vf-text vf-text-heading--4">For press</h3>
     <a href="http://www.embl.de/aboutus/communication_outreach/media_relations/index.html?_ga=2.70344536.995063798.1574846519-497306958.1561211067"
       class="vf-link | vf-u-padding__bottom--sm | press-link" style="color: white;">Press release archive</a>
     <a href="https://www.embl.de/aboutus/communication_outreach/media_relations/index.html"
       class="vf-link | vf-u-padding__bottom--sm | press-link" style="color: white;">Contact Press Office</a>
   </div>
-  <div class="vf-u-background-color--grey--dark | vf-u-padding--md | vf-u-fullbleed ">
+  <div class="vf-u-padding--md">
     <h3 class="vf-text vf-text-heading--4">Follow us</h3>
     <a href="https://twitter.com/embl"><i class="social fab fa-twitter-square"></i></a>
     <a href="https://www.facebook.com/embl.org/"><i class="social fab fa-facebook-square"></i></a>


### PR DESCRIPTION
There might be a better way to do this, not sure fully what was intended. 

Fixes a horiz overflow with:

- drop vf-grid for embl-grid
- remove vf-u-full-bleed from the last child

Bonus
- remove some uneeded `vf-u-background-color--grey--dark`


---

Before:

![image](https://user-images.githubusercontent.com/928100/76881398-5a16da00-6879-11ea-8957-132bb13735b3.png)


After:

![image](https://user-images.githubusercontent.com/928100/76881368-508d7200-6879-11ea-8cfc-75b8eb64f136.png)
