### PR TITLE
Remove all Gutenberg default styling

### DIFF
--- a/wp-content/themes/vf-wp/functions/theme.php
+++ b/wp-content/themes/vf-wp/functions/theme.php
@@ -371,6 +371,10 @@ class VF_Theme {
     );
     wp_enqueue_script('jquery');
 
+    // remove all default gutenberg styling
+    // this file: wp-includes/css/dist/block-library/style.min.css
+    wp_dequeue_style('wp-block-library');
+
     // Add VF stylesheet if global option exists
     if (function_exists('vf_get_stylesheet') && vf_get_stylesheet()) {
       wp_enqueue_style(


### PR DESCRIPTION
This one would help us in many conflict areas by removing the default gutenberg styling from the frontend (still present in the editor).

Specifically, it addresses #184, but should also help with pullquotes and other misc things.

There's a chance of some regressions where we were being helped by the defaults but didn't know it, so we should test before rolling out. But a quick look suggests :+1:

I can't recall why David hadn't done this, perhaps the VF just wasn't far enough along at the time.