### PR TITLE
feature/wp-containers

### DIFF
--- a/docs/blocks.md
+++ b/docs/blocks.md
@@ -5,7 +5,6 @@ Blocks are small, reusable content patterns. Blocks may appear within the Gutenb
 * [Factoid](/wp-content/plugins/vf-factoid-block/README.md)
 * [Group Header](/wp-content/plugins/vf-group-header-block/README.md)
 * [Jobs](/wp-content/plugins/vf-jobs-block/README.md)
-* [Latest Posts](/wp-content/plugins/vf-latest-posts-block/README.md)
 * [Members](/wp-content/plugins/vf-members-block/README.md)
 * [Publications](/wp-content/plugins/vf-publications-block/README.md)
 
@@ -14,3 +13,10 @@ Default block settings are configured under **VF Blocks** in the Admin area. See
 The `vf-gutenberg` plugin automatically generates React components for the Gutenberg editor.
 
 Blocks have the custom post type: `vf_block`.
+
+## Advanced Custom Fields
+
+Other blocks are registered with ACF:
+
+* [Latest Posts](/wp-content/themes/vf-wp/blocks/vfwp-latest-posts/README.md)
+* [Events List](/wp-content/plugins/vf-events/README.md#gutenberg-block)

--- a/wp-content/plugins/vf-beta-container/README.md
+++ b/wp-content/plugins/vf-beta-container/README.md
@@ -2,6 +2,8 @@
 
 **This plugin is deprecated** – notificated are added via the content hub.
 
+* * *
+
 Display the Beta notification from the Content Hub.
 
 ## Configuration

--- a/wp-content/plugins/vf-beta-container/index.php
+++ b/wp-content/plugins/vf-beta-container/index.php
@@ -17,6 +17,10 @@ require_once($path);
 
 class VF_Beta extends VF_Plugin {
 
+  public function is_deprecated() {
+    return true;
+  }
+
   protected $file = __FILE__;
 
   protected $config = array(

--- a/wp-content/plugins/vf-events/README.md
+++ b/wp-content/plugins/vf-events/README.md
@@ -102,6 +102,6 @@ VF_Events::get_archive_pages();
 
 Returns an array of `next` and `previous` archive page URLs. These values will be `false` if there is no page.
 
-# Gutenberg Block
+## Gutenberg block
 
 This plugin registers an "Events List" block using ACF.

--- a/wp-content/plugins/vf-events/README.md
+++ b/wp-content/plugins/vf-events/README.md
@@ -78,8 +78,6 @@ single-vf_event.php
 
 ## Template Functions
 
-
-
 ```php
 VF_Events::is_upcoming_archive();
 ```
@@ -104,3 +102,6 @@ VF_Events::get_archive_pages();
 
 Returns an array of `next` and `previous` archive page URLs. These values will be `false` if there is no page.
 
+# Gutenberg Block
+
+This plugin registers an "Events List" block using ACF.

--- a/wp-content/plugins/vf-example-block/template.php
+++ b/wp-content/plugins/vf-example-block/template.php
@@ -2,20 +2,20 @@
 
 global $post;
 
-$text = get_field('vf_example_text', $post->ID);
-$textarea = get_field('vf_example_textarea', $post->ID);
-$select = get_field('vf_example_select', $post->ID);
-$range = get_field('vf_example_range', $post->ID);
-$radio = get_field('vf_example_radio', $post->ID);
-$checkbox = get_field('vf_example_checkbox', $post->ID);
-$boolean = get_field('vf_example_boolean', $post->ID);
-$date = get_field('vf_example_date', $post->ID);
-$taxonomy = get_field('vf_example_taxonomy', $post->ID);
+$text = get_field('vf_example_text');
+$textarea = get_field('vf_example_textarea');
+$select = get_field('vf_example_select');
+$range = get_field('vf_example_range');
+$radio = get_field('vf_example_radio');
+$checkbox = get_field('vf_example_checkbox');
+$boolean = get_field('vf_example_boolean');
+$date = get_field('vf_example_date');
+$taxonomy = get_field('vf_example_taxonomy');
 $checkbox = is_array($checkbox) ? $checkbox : array();
-$number = get_field('vf_example_number', $post->ID);
-$email = get_field('vf_example_email', $post->ID);
-$url = get_field('vf_example_url', $post->ID);
-$rich = get_field('vf_example_rich', $post->ID);
+$number = get_field('vf_example_number');
+$email = get_field('vf_example_email');
+$url = get_field('vf_example_url');
+$rich = get_field('vf_example_rich');
 
 ?>
 <div class="vf-content">

--- a/wp-content/plugins/vf-gutenberg/vf-gutenberg.php
+++ b/wp-content/plugins/vf-gutenberg/vf-gutenberg.php
@@ -483,6 +483,9 @@ class VF_Gutenberg {
           'reusable'        => false
         );
       }
+      if ($plugin->is_deprecated()) {
+        $data['supports']['inserter'] = false;
+      }
       $config[$block_name] = $data;
     }
     // Add generic plugin for previews

--- a/wp-content/plugins/vf-gutenberg/vf-gutenberg.php
+++ b/wp-content/plugins/vf-gutenberg/vf-gutenberg.php
@@ -566,32 +566,34 @@ class VF_Gutenberg {
    * $args = array($block, $content, $is_preview, $post_id)
    */
   static function acf_render_template($args, $template) {
+    $is_preview = $args[2];
     if ( ! file_exists($template)) {
-      if ($args[2]) {
+      if ($is_preview) {
         echo __('Block template missing.', 'vfwp');
       }
       return;
     }
+    $block = $args[0];
     // Capture the block template
     ob_start();
     // Output head include for preview
-    if ($args[2]) {
+    if ($is_preview) {
       get_template_part('partials/head');
     }
     // Load template
-    load_template($template, true, false);
+    include($template);
     // Output foot include for preview
-    if ($args[2]) {
+    if ($is_preview) {
       get_template_part('partials/foot');
     }
     $html = ob_get_contents();
     ob_end_clean();
     // Render block if not admin preview
-    if ($args[2] !== true) {
+    if ($is_preview !== true) {
       echo $html;
       return;
     }
-    $id = "vfwp_{$args[0]['id']}";
+    $id = "vfwp_{$block['id']}";
 ?>
 <script>
 window.<?php echo $id; ?> = function() {

--- a/wp-content/plugins/vf-latest-posts-block/README.md
+++ b/wp-content/plugins/vf-latest-posts-block/README.md
@@ -2,6 +2,8 @@
 
 **This plugin is deprecated** – the block can be replaced by an `acf/vfwp-latest-posts` block provided by the `vf-wp` theme.
 
+Please refer to the new [Latest Posts README](/wp-content/themes/vf-wp/blocks/vfwp-latest-posts/README.md).
+
 * * *
 
 The latest WordPress blog post in a `vf-summary--article` Visual Framework pattern followed by three more aside in a `vf-box--inlay` pattern.

--- a/wp-content/plugins/vf-latest-posts-block/README.md
+++ b/wp-content/plugins/vf-latest-posts-block/README.md
@@ -1,4 +1,8 @@
-# Latest Posts (block)
+# Latest Posts (block) – DEPRECATED
+
+**This plugin is deprecated** – the block can be replaced by an `acf/vfwp-latest-posts` block provided by the `vf-wp` theme.
+
+* * *
 
 The latest WordPress blog post in a `vf-summary--article` Visual Framework pattern followed by three more aside in a `vf-box--inlay` pattern.
 

--- a/wp-content/plugins/vf-latest-posts-block/index.php
+++ b/wp-content/plugins/vf-latest-posts-block/index.php
@@ -1,6 +1,6 @@
 <?php
 /*
-Plugin Name: VF-WP Latest Posts
+Plugin Name: VF-WP Latest Posts (Deprecated)
 Description: VF-WP theme block.
 Version: 0.1.2
 Author: EMBL-EBI Web Development

--- a/wp-content/plugins/vf-latest-posts-block/index.php
+++ b/wp-content/plugins/vf-latest-posts-block/index.php
@@ -37,6 +37,10 @@ class VF_Latest_Posts extends VF_Plugin {
   private function init() {
     parent::initialize();
     add_action('admin_head', array($this, 'admin_head'), 15);
+    add_action(
+      'admin_print_footer_scripts',
+      array($this, 'admin_print_footer_scripts')
+    );
   }
 
   function is_template_standalone() {
@@ -50,6 +54,36 @@ class VF_Latest_Posts extends VF_Plugin {
   max-width: none;
 }
 </style>
+<?php
+  }
+
+  function admin_print_footer_scripts() {
+    if ( ! function_exists('get_current_screen')) {
+      return;
+    }
+    $screen = get_current_screen();
+    if ($screen->base !== 'post' || $screen->id !== 'vf_block') {
+      return;
+    }
+    global $post;
+    if (
+      ! $post instanceof WP_Post ||
+      ! $post->post_name === $this->config['post_name']
+    ) {
+      return;
+    }
+?>
+<script type="text/javascript">
+(function(wp) {
+  wp.data.dispatch('core/notices').createNotice(
+    'error',
+    'This block is deprecated! Please refer to the new version found in the "EMBL – WordPress" editor category.',
+    {
+      isDismissible: false
+    }
+  );
+})(window.wp);
+</script>
 <?php
   }
 

--- a/wp-content/plugins/vf-latest-posts-block/index.php
+++ b/wp-content/plugins/vf-latest-posts-block/index.php
@@ -16,6 +16,10 @@ require_once($path);
 
 class VF_Latest_Posts extends VF_Plugin {
 
+  public function is_deprecated() {
+    return true;
+  }
+
   protected $file = __FILE__;
 
   protected $config = array(

--- a/wp-content/plugins/vf-latest-posts-block/template.php
+++ b/wp-content/plugins/vf-latest-posts-block/template.php
@@ -13,67 +13,28 @@ $heading_singular = trim($heading_singular);
 $heading_plural = get_field('vf_latest_posts_heading_plural', $post->ID);
 $heading_plural = trim($heading_plural);
 
-if (empty($heading_singular)) {
-  $heading_singular = __('Latest blog post', 'vfwp');
+// Use the theme provided ACF block template
+$path = locate_template('blocks/vfwp-latest-posts/template.php');
+if ( ! file_exists($path)) {
+  return;
 }
 
-if (empty($heading_plural)) {
-  $heading_plural = __('Latest posts', 'vfwp');
-}
+// Setup a "fake" ACF block
+$block = array(
+  'id'   => uniqid('block_'),
+  'name' => 'acf/vfwp-latest-posts',
+  'data' => array(
+    'heading_singular'  => $heading_singular,
+    '_heading_singular' => 'field_5e99679631cbd',
+    'heading_plural'    => $heading_plural,
+    '_heading_plural'   => 'field_5e9967a331cbe',
+  )
+);
+$block = acf_prepare_block($block);
 
-$latest_posts = get_posts(array(
-  'posts_per_page' => 3
-));
+// Render the ACF block
+acf_setup_meta( $block['data'], $block['id'], true );
+include($path);
+acf_reset_meta( $block['id'] );
 
-if (count($latest_posts)) {
-  // Setup first post data so template tags worl
-  global $post;
-  $old_post = $post;
-  setup_postdata($post = $latest_posts[0]);
 ?>
-<section class="vf-inlay">
-  <div class="vf-inlay__content vf-u-background-color-ui--white">
-    <main class="vf-inlay__content--main">
-      <?php if ( ! empty($heading_singular)) { ?>
-      <div class="vf-section-header">
-        <h2 class="vf-section-header__heading"><?php echo esc_html($heading_singular); ?></h2>
-      </div>
-      <?php } ?>
-      <article class="vf-summary vf-summary--article">
-        <h2 class="vf-summary__title">
-          <a href="<?php the_permalink(); ?>" class="vf-summary__link"><?php echo esc_html(get_the_title()); ?></a>
-        </h2>
-        <span class="vf-summary__meta">
-          <a class="vf-summary__author vf-summary__link" href="<?php echo get_author_posts_url(get_the_author_meta('ID')); ?>"><?php the_author(); ?></a>
-          <time class="vf-summary__date" title="<?php the_time('c'); ?>" datetime="<?php the_time('c'); ?>"><?php the_time(get_option('date_format')); ?></time>
-      <?php if (comments_open()) { ?>
-          <a class="vf-summary__link" href="<?php the_permalink(); ?>#respond"><?php _e('Leave a comment', 'vfwp'); ?></a>
-      <?php } ?>
-        </span>
-        <p class="vf-summary__text"><?php echo get_the_excerpt(); ?></p>
-      </article>
-      <!--/vf-summary-->
-    </main>
-    <aside class="vf-inlay__content--additional">
-
-      <div class="vf-links | vf-box vf-box--inlay">
-        <h3 class="vf-links__heading"><?php echo esc_html($heading_plural); ?></h3>
-        <ul class="vf-links__list | vf-list">
-          <?php foreach ($latest_posts as $latest) { ?>
-          <li class="vf-list__item">
-            <a class="vf-list__link" href="<?php the_permalink($latest->ID); ?>"><?php echo esc_html(get_the_title($latest->ID)); ?></a>
-          </li>
-          <?php } ?>
-        </ul>
-      </div>
-
-    </aside>
-  </div>
-</section>
-<?php
-  // Reset post data back to plugin
-  setup_postdata($post = $old_post);
-}
-?>
-
-

--- a/wp-content/plugins/vf-wp/index.php
+++ b/wp-content/plugins/vf-wp/index.php
@@ -183,7 +183,7 @@ class VF_WP {
       array(
         array(
           'slug'  => 'vf/wp',
-          'title' => __('EMBL – WordPress', 'vfwp'),
+          'title' => __('EMBL – WordPress (local content)', 'vfwp'),
           'icon'  => null
         ),
       ),

--- a/wp-content/plugins/vf-wp/vf-plugin.php
+++ b/wp-content/plugins/vf-wp/vf-plugin.php
@@ -155,6 +155,15 @@ class VF_Plugin {
   }
 
   /**
+   * Return true if plugin is deprecated (override per plugin)
+   * New Gutenberg blocks cannot be added (`inserter` = `false`)
+   * Existing Gutenberg blocks are still rendered if plugin is active
+   */
+  public function is_deprecated() {
+    return false;
+  }
+
+  /**
    * Return true if template has grid wrappers and should not be contained
    */
   public function is_template_standalone() {

--- a/wp-content/plugins/vf-wp/vf-plugin.php
+++ b/wp-content/plugins/vf-wp/vf-plugin.php
@@ -385,29 +385,12 @@ class VF_Plugin {
       return;
     }
 
-    /**
-     * We're setting up postdata for the canonical plugin post but for
-     * customized blocks we need to override some ACF fields
-     * If custom field values are provided use `acf/pre_load_value` filter
-     * to bypass the plugin defaults
-     */
-    $pre_load_value = function ($value, $post_id, $field)
-      use ($plugin, $fields)
-    {
-      // Filter the plugin post only (when custom field exists)
-      if (
-        $post_id === $plugin->post()->ID &&
-        array_key_exists($field['name'], $fields)
-      ) {
-        acf_flush_value_cache($plugin->post()->ID, $field['name']);
-        $value = $fields[$field['name']];
-      }
-      return $value;
-    };
-
+    // Flush the ACF cache and setup post meta
     if (is_array($fields)) {
-      add_filter('acf/pre_load_value', $pre_load_value, 10, 3);
-      // acf_setup_meta($fields, $plugin->post()->ID, true);
+      foreach (array_keys($fields) as $field_name) {
+        acf_flush_value_cache($plugin->post()->ID, $field_name);
+      }
+      acf_setup_meta($fields, $plugin->post()->ID, true);
     }
 
     // Before actions
@@ -424,6 +407,14 @@ class VF_Plugin {
     // Include the plugin template
     include($vf_plugin->template());
 
+    // Flush the ACF cache *again* and reset the post meta
+    if (is_array($fields)) {
+      acf_reset_meta($post->ID);
+      foreach (array_keys($fields) as $field_name) {
+        acf_flush_value_cache($post->ID, $field_name);
+      }
+    }
+
     // Reset globals to parent plugin (or main template loop)
     if ($parent instanceof VF_Plugin) {
       $vf_plugin = $parent;
@@ -432,16 +423,6 @@ class VF_Plugin {
     } else {
       $vf_plugin = null;
       wp_reset_postdata();
-    }
-
-    // Clear any cached values if custom config is used
-    if (is_array($fields)) {
-      remove_filter('acf/pre_load_value', $pre_load_value, 10, 3);
-      foreach (array_keys($fields) as $field_name) {
-        acf_flush_value_cache($plugin->post()->ID, $field_name);
-      }
-      // Just in case...
-      acf_reset_meta($plugin->post()->ID);
     }
 
     // After actions

--- a/wp-content/themes/vf-wp/blocks/vfwp-latest-posts/README.md
+++ b/wp-content/themes/vf-wp/blocks/vfwp-latest-posts/README.md
@@ -1,0 +1,44 @@
+# Latest Posts (block)
+
+The latest WordPress blog post in a `vf-summary--article` Visual Framework pattern followed by three more aside in a `vf-box--inlay` pattern.
+
+## Configuration
+
+ACF / Block data:
+
+| meta_key | meta_name | meta_value |
+| -------- | --------- | ---------- |
+| field_5e99679631cbd | heading_singular | [STRING] |
+| field_5e9967a331cbe | heading_plural | [STRING] |
+
+Block `name`: `acf/vfwp-latest-posts`
+
+Block `id` must be unique per instance in the post content. If multiple instances use a random ID, e.g. [uniqid('block_')](https://www.php.net/manual/en/function.uniqid.php).
+
+### Block (minimal/defaults)
+
+```html
+<!-- wp:acf/vfwp-latest-posts {"id":"block_5ea826258cfbb","name":"acf/vfwp-latest-posts"} /-->
+```
+
+### Block (configured)
+
+```html
+<!-- wp:acf/vfwp-latest-posts {"id":"block_5ea826da451bc","name":"acf/vfwp-latest-posts","data":{"field_5e99679631cbd":"Latest","field_5e9967a331cbe":"More"},"mode":"preview"} /-->
+```
+
+Full block `data` and `mode` properties should be added if configured.
+
+### Heading (singular)
+
+**Key**: `vf_latest_posts_heading_singular`
+**Value**: string (template default: "Latest blog post")
+
+An optional heading above the single post using the `vf-section-header` VF pattern. If empty no heading is displayed.
+
+### Heading (plural)
+
+**Key**: `vf_latest_posts_heading_singular`
+**Value**: string (template default: "Latest posts")
+
+An optional heading inside the box aside above the three additional posts. If empty no heading is displayed.

--- a/wp-content/themes/vf-wp/blocks/vfwp-latest-posts/README.md
+++ b/wp-content/themes/vf-wp/blocks/vfwp-latest-posts/README.md
@@ -37,6 +37,6 @@ An optional heading above the single post using the `vf-section-header` VF patte
 
 ### Heading (plural)
 
-Ttemplate default: "Latest posts"
+Template default: "Latest posts"
 
 An optional heading inside the box aside above the three additional posts. If empty no heading is displayed.

--- a/wp-content/themes/vf-wp/blocks/vfwp-latest-posts/README.md
+++ b/wp-content/themes/vf-wp/blocks/vfwp-latest-posts/README.md
@@ -1,6 +1,6 @@
 # Latest Posts (block)
 
-The latest WordPress blog post in a `vf-summary--article` Visual Framework pattern followed by three more aside in a `vf-box--inlay` pattern.
+Display the latest WordPress blog post in a `vf-summary--article` Visual Framework pattern followed by three more aside in a `vf-box--inlay` pattern.
 
 ## Configuration
 
@@ -13,7 +13,7 @@ ACF / Block data:
 
 Block `name`: `acf/vfwp-latest-posts`
 
-Block `id` must be unique per instance in the post content. If multiple instances use a random ID, e.g. [uniqid('block_')](https://www.php.net/manual/en/function.uniqid.php).
+Block `id` must be unique per instance in the post content. Use a random ID, e.g. [`uniqid('block_')`](https://www.php.net/manual/en/function.uniqid.php).
 
 ### Block (minimal/defaults)
 
@@ -31,14 +31,12 @@ Full block `data` and `mode` properties should be added if configured.
 
 ### Heading (singular)
 
-**Key**: `vf_latest_posts_heading_singular`
-**Value**: string (template default: "Latest blog post")
+Template default: "Latest blog post"
 
 An optional heading above the single post using the `vf-section-header` VF pattern. If empty no heading is displayed.
 
 ### Heading (plural)
 
-**Key**: `vf_latest_posts_heading_singular`
-**Value**: string (template default: "Latest posts")
+Ttemplate default: "Latest posts"
 
 An optional heading inside the box aside above the three additional posts. If empty no heading is displayed.

--- a/wp-content/themes/vf-wp/blocks/vfwp-latest-posts/acf.json
+++ b/wp-content/themes/vf-wp/blocks/vfwp-latest-posts/acf.json
@@ -1,0 +1,62 @@
+{
+  "key": "group_5e9967ec34eec",
+  "title": "Latest Posts",
+  "fields": [
+    {
+      "key": "field_5e99679631cbd",
+      "label": "Heading (singular)",
+      "name": "heading_singular",
+      "type": "text",
+      "instructions": "",
+      "required": 0,
+      "conditional_logic": 0,
+      "wrapper": {
+        "width": "",
+        "class": "",
+        "id": ""
+      },
+      "default_value": "",
+      "placeholder": "",
+      "prepend": "",
+      "append": "",
+      "maxlength": ""
+    },
+    {
+      "key": "field_5e9967a331cbe",
+      "label": "Heading (plural)",
+      "name": "heading_plural",
+      "type": "text",
+      "instructions": "",
+      "required": 0,
+      "conditional_logic": 0,
+      "wrapper": {
+        "width": "",
+        "class": "",
+        "id": ""
+      },
+      "default_value": "",
+      "placeholder": "",
+      "prepend": "",
+      "append": "",
+      "maxlength": ""
+    }
+  ],
+  "location": [
+    [
+      {
+        "param": "block",
+        "operator": "==",
+        "value": "acf/vfwp-latest-posts"
+      }
+    ]
+  ],
+  "menu_order": 0,
+  "position": "normal",
+  "style": "seamless",
+  "label_placement": "top",
+  "instruction_placement": "label",
+  "hide_on_screen": "",
+  "active": 1,
+  "description": "`acf/vfwp-latest-posts` block",
+  "modified": 1587111791
+}

--- a/wp-content/themes/vf-wp/blocks/vfwp-latest-posts/index.php
+++ b/wp-content/themes/vf-wp/blocks/vfwp-latest-posts/index.php
@@ -78,11 +78,13 @@ class VFWP_Latest_Posts {
   public function acf_init() {
     // Setup render callback using VF Gutenberg plugin or fallback
     $callback = function() {
+      $args = func_get_args();
       $template = $this->get_template();
       if (class_exists('VF_Gutenberg')) {
-        VF_Gutenberg::acf_render_template(func_get_args(), $template);
+        VF_Gutenberg::acf_render_template($args, $template);
       } else {
-        load_template($template, true, false);
+        $block = $args[0];
+        include($template);
       }
     };
     // Register the Gutenberg block with ACF

--- a/wp-content/themes/vf-wp/blocks/vfwp-latest-posts/index.php
+++ b/wp-content/themes/vf-wp/blocks/vfwp-latest-posts/index.php
@@ -1,0 +1,132 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) exit;
+
+if ( ! class_exists('VF_WP_Latest_Posts') ) :
+
+class VFWP_Latest_Posts {
+
+  /**
+   * Return the block name
+   */
+  static public function get_name() {
+    return 'vfwp-latest-posts';
+  }
+
+  /**
+   * Constructor - add hooks
+   */
+  public function __construct() {
+    add_action('acf/init',
+      array($this, 'acf_init')
+    );
+    add_filter(
+      'acf/settings/load_json',
+      array($this, 'acf_settings_load_json')
+    );
+    add_filter(
+      "vf/theme/content/is_block_wrapped/name=acf/{$this->get_name()}",
+      array($this, 'is_block_wrapped')
+    );
+    add_action('admin_head',
+      array($this, 'admin_head')
+    );
+  }
+
+  /**
+   * Return Gutenberg block registration configuration
+   * https://www.advancedcustomfields.com/resources/acf_register_block_type/
+   * https://developer.wordpress.org/block-editor/developers/block-api/block-registration/
+   */
+  public function get_config() {
+    return array(
+      'name'     => $this->get_name(),
+      'title'    => 'Latest Posts',
+      'category' => 'vf/wp',
+      'supports' => array(
+        'align'           => false,
+        'customClassName' => false
+      )
+    );
+  }
+
+  /**
+   * Return block render template path
+   */
+  public function get_template() {
+    // Allow themes to provide a custom template
+    $template = locate_template(
+      "blocks/{$this->get_name()}.php",
+      false, false
+    );
+    if ( ! file_exists($template)) {
+      $template = locate_template(
+        "blocks/{$this->get_name()}/template.php",
+        false, false
+      );
+    }
+    // Otherwise default to the plugin template
+    // if ( ! file_exists($template)) {
+    //   $template = plugin_dir_path(__FILE__) . 'template.php';
+    // }
+    return $template;
+  }
+
+  /**
+   * Action: `acf/init`
+   */
+  public function acf_init() {
+    // Setup render callback using VF Gutenberg plugin or fallback
+    $callback = function() {
+      $template = $this->get_template();
+      if (class_exists('VF_Gutenberg')) {
+        VF_Gutenberg::acf_render_template(func_get_args(), $template);
+      } else {
+        load_template($template, true, false);
+      }
+    };
+    // Register the Gutenberg block with ACF
+    acf_register_block_type(array_merge(
+      $this->get_config(),
+      array(
+        'render_callback' => $callback
+      )
+    ));
+  }
+
+  /**
+   * Filter: `acf/settings/load_json`
+   */
+  public function acf_settings_load_json($paths) {
+    $paths[] = plugin_dir_path(__FILE__);
+    return $paths;
+  }
+
+  /**
+   * Do not wrap the block in `vf-content`
+   */
+  public function is_block_wrapped($is_wrap) {
+    return false;
+  }
+
+  /**
+   * Add custom CSS for the WordPress Admin area
+   */
+  public function admin_head() {
+?>
+<style>
+.wp-block[data-type="acf/<?php echo $this->get_name(); ?>"] {
+  max-width: none;
+}
+</style>
+<?php
+  }
+
+} // VF_WP_Latest_Posts
+
+// Initialize one instance
+$vfwp_latest_posts = new VFWP_Latest_Posts();
+
+endif;
+
+?>

--- a/wp-content/themes/vf-wp/blocks/vfwp-latest-posts/template.php
+++ b/wp-content/themes/vf-wp/blocks/vfwp-latest-posts/template.php
@@ -1,0 +1,70 @@
+<?php
+
+$heading_singular = get_field('heading_singular');
+$heading_singular = trim($heading_singular);
+
+$heading_plural = get_field('heading_plural');
+$heading_plural = trim($heading_plural);
+
+if (empty($heading_singular)) {
+  $heading_singular = __('Latest blog post', 'vfwp');
+}
+
+if (empty($heading_plural)) {
+  $heading_plural = __('Latest posts', 'vfwp');
+}
+
+$latest_posts = get_posts(array(
+  'posts_per_page' => 3
+));
+
+if (count($latest_posts)) {
+  // Setup first post data so template tags work
+  global $post;
+  $old_post = $post;
+  setup_postdata($post = $latest_posts[0]);
+?>
+<section class="vf-inlay">
+  <div class="vf-inlay__content vf-u-background-color-ui--white">
+    <main class="vf-inlay__content--main">
+      <?php if ( ! empty($heading_singular)) { ?>
+      <div class="vf-section-header">
+        <h2 class="vf-section-header__heading"><?php echo esc_html($heading_singular); ?></h2>
+      </div>
+      <?php } ?>
+      <article class="vf-summary vf-summary--article">
+        <h2 class="vf-summary__title">
+          <a href="<?php the_permalink(); ?>" class="vf-summary__link"><?php echo esc_html(get_the_title()); ?></a>
+        </h2>
+        <span class="vf-summary__meta">
+          <a class="vf-summary__author vf-summary__link" href="<?php echo get_author_posts_url(get_the_author_meta('ID')); ?>"><?php the_author(); ?></a>
+          <time class="vf-summary__date" title="<?php the_time('c'); ?>" datetime="<?php the_time('c'); ?>"><?php the_time(get_option('date_format')); ?></time>
+      <?php if (comments_open()) { ?>
+          <a class="vf-summary__link" href="<?php the_permalink(); ?>#respond"><?php _e('Leave a comment', 'vfwp'); ?></a>
+      <?php } ?>
+        </span>
+        <p class="vf-summary__text"><?php echo get_the_excerpt(); ?></p>
+      </article>
+      <!--/vf-summary-->
+    </main>
+    <aside class="vf-inlay__content--additional">
+
+      <div class="vf-links | vf-box vf-box--inlay">
+        <h3 class="vf-links__heading"><?php echo esc_html($heading_plural); ?></h3>
+        <ul class="vf-links__list | vf-list">
+          <?php foreach ($latest_posts as $latest) { ?>
+          <li class="vf-list__item">
+            <a class="vf-list__link" href="<?php the_permalink($latest->ID); ?>"><?php echo esc_html(get_the_title($latest->ID)); ?></a>
+          </li>
+          <?php } ?>
+        </ul>
+      </div>
+
+    </aside>
+  </div>
+</section>
+<?php
+  // Reset post data back to plugin
+  setup_postdata($post = $old_post);
+}
+?>

--- a/wp-content/themes/vf-wp/functions.php
+++ b/wp-content/themes/vf-wp/functions.php
@@ -7,6 +7,9 @@ require_once('functions/walker-comment.php');
 require_once('functions/admin.php');
 require_once('functions/theme.php');
 
+// Require container classes
+require_once("blocks/vfwp-latest-posts/index.php");
+
 global $vf_admin;
 if ( ! isset($vf_admin)) {
   $vf_admin = new VF_Admin();

--- a/wp-content/themes/vf-wp/functions/theme-content.php
+++ b/wp-content/themes/vf-wp/functions/theme-content.php
@@ -179,6 +179,10 @@ class VF_Theme_Content {
         'vf/theme/content/is_block_wrapped',
         false, $block_name, $blocks, $i
       );
+      $is_wrap = (bool) VF_Theme::apply_filters(
+        "vf/theme/content/is_block_wrapped/name={$block_name}",
+        $is_wrap, $blocks, $i
+      );
       $before  = '';
       $prefix = '';
       $suffix = '';


### PR DESCRIPTION
This PR:

* improves internal code to render blocks and plugins
* deprecates the "Latest News" plugin in favour of a new ACF block (identical template) with temporary backwards-compatibility
* new "Latest News" ACF block in the `vf-wp` theme directory
* updated Gutenberg block categories (including "EMBL – WordPress")