### PR TITLE
changes the element from <header> to <div>

### DIFF
--- a/wp-content/themes/vf-wp-news/header.php
+++ b/wp-content/themes/vf-wp-news/header.php
@@ -1,6 +1,6 @@
 <?php get_template_part('partials/head'); ?>
 <?php vf_header(); ?>
 
-<header class="vf-header vf-header--inlay">
+<div class="vf-header vf-header--inlay">
   <?php get_template_part('partials/vf-masthead'); ?>
-</header>
+</div>


### PR DESCRIPTION
There should only be one `<header>` element within a parent element. Currently there are two inside of `<body>` this is one that doesn't need to be a `<header>`.

This is a quick-fix in lieu of replacing this with the `vf-breadcrumb` component.