### PR TITLE
DOCUMENTATION - Publishing notes and versioning

### DIFF
--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -1,0 +1,27 @@
+# PUBLISHING
+
+A reference guide on how to do releases of `vf-wp`, and its themes+plugins. The two are done independently.
+
+## `vf-wp` project
+
+The `vf-wp` is a parent project. It is the bundling of the themes, plugins and some configuration.
+
+1. Go to the add a new release on GitHub
+  - https://github.com/visual-framework/vf-wp/releases
+1. Add a new version number
+  - these are semantic versions
+1. Add release notes, emphasizing any breaking changes or changes in deployment
+1. Notify EMBL-EBI Web Development of the new version
+
+## Themes and plugins inside `vf-wp`
+
+Components are contained in a [monorepo](https://gomonorepo.org) inside of the `vf-wp` project. They are NOT individually published. When changes are made to the plugins and themes inside `vf-wp`, their version numbers should be updated accordingly.
+
+For example:
+
+- [wp-content/plugins/embl-taxonomy/embl-taxonomy.php](https://github.com/visual-framework/vf-wp/blob/master/wp-content/plugins/embl-taxonomy/embl-taxonomy.php#L6)
+- [wp-content/themes/vf-wp-news/style.css](https://github.com/visual-framework/vf-wp/blob/master/wp-content/themes/vf-wp-news/style.css#L8)
+
+Updating the versions on these `vf-wp` child assets will allow the current version of the plugins and theme to be seen from the WordPress admin interface.
+
+The versions of the child assets do not need to match `vf-wp` and can be independently and semantically versioned.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vf-wp",
-  "version": "0.3.0",
+  "version": "1.0.0-beta.1",
   "private": true,
   "description": "Visual Framework WordPress Theme",
   "main": "gulpfile.js",

--- a/wp-content/plugins/embl-group-site-roles/embl-group-site-roles.php
+++ b/wp-content/plugins/embl-group-site-roles/embl-group-site-roles.php
@@ -2,7 +2,7 @@
 /*
 * Plugin Name: EMBL Group Site Roles
 * Description: Custom roles setup for EMBL Groups websites
-* Version: 0.0.1
+* Version: 1.0.0-beta.1
 * Text Domain: embl-group-site-roles
 * Author: Joseph Rossetto <jros@ebi.ac.uk>
 */

--- a/wp-content/plugins/embl-taxonomy/embl-taxonomy.php
+++ b/wp-content/plugins/embl-taxonomy/embl-taxonomy.php
@@ -3,7 +3,7 @@
 Plugin Name: EMBL Taxonomy
 Plugin URI: https://github.com/visual-framework/vf-wp
 Description: Adds EMBL Taxonomy integration to tag posts with EMBL Taxonomy terms.
-Version: 0.0.3
+Version: 1.0.0-beta.1
 Author: EMBL-EBI Web Development
 */
 

--- a/wp-content/plugins/vf-beta-container/index.php
+++ b/wp-content/plugins/vf-beta-container/index.php
@@ -3,7 +3,7 @@
 Deprecated: 0.2.2
 Plugin Name: VF-WP Beta (Deprecated)
 Description: This plugin is deprecated and can be uninstalled.
-Version: 0.2.2
+Version: 1.0.0-beta.1
 Author: EMBL-EBI Web Development
 Plugin URI: https://github.com/visual-framework/vf-wp
 Text Domain: vfwp

--- a/wp-content/plugins/vf-breadcrumbs-container/index.php
+++ b/wp-content/plugins/vf-breadcrumbs-container/index.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: VF-WP Breadcrumbs
 Description: VF-WP theme global container.
-Version: 0.1.1
+Version: 1.0.0-beta.1
 Author: EMBL-EBI Web Development
 Plugin URI: https://github.com/visual-framework/vf-wp
 Text Domain: vfwp

--- a/wp-content/plugins/vf-data-resources-block/index.php
+++ b/wp-content/plugins/vf-data-resources-block/index.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: VF-WP Data resources
 Description: VF-WP theme block.
-Version: 0.1.3
+Version: 1.0.0-beta.1
 Author: EMBL-EBI Web Development
 Plugin URI: https://github.com/visual-framework/vf-wp
 Text Domain: vfwp

--- a/wp-content/plugins/vf-ebi-global-footer-container/index.php
+++ b/wp-content/plugins/vf-ebi-global-footer-container/index.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: VF-WP EBI VF 1.3 Global Footer
 Description: VF-WP theme global container.
-Version: 0.1.3
+Version: 1.0.0-beta.1
 Author: EMBL-EBI Web Development
 Plugin URI: https://github.com/visual-framework/vf-wp
 Text Domain: vfwp

--- a/wp-content/plugins/vf-ebi-global-header-container/index.php
+++ b/wp-content/plugins/vf-ebi-global-header-container/index.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: VF-WP EBI VF 1.3 Global Header
 Description: VF-WP theme global container.
-Version: 0.1.2
+Version: 1.0.0-beta.1
 Author: EMBL-EBI Web Development
 Plugin URI: https://github.com/visual-framework/vf-wp
 Text Domain: vfwp

--- a/wp-content/plugins/vf-embl-news-block/index.php
+++ b/wp-content/plugins/vf-embl-news-block/index.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: VF-WP EMBL News (Gutenberg block)
 Description: VF-WP theme Gutenberg block.
-Version: 0.1.0
+Version: 1.0.0-beta.1
 Author: EMBL-EBI Web Development
 Plugin URI: https://github.com/visual-framework/vf-wp
 Text Domain: vfwp

--- a/wp-content/plugins/vf-embl-news-container/index.php
+++ b/wp-content/plugins/vf-embl-news-container/index.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: VF-WP EMBL News
 Description: VF-WP theme global container.
-Version: 0.1.2
+Version: 1.0.0-beta.1
 Author: EMBL-EBI Web Development
 Plugin URI: https://github.com/visual-framework/vf-wp
 Text Domain: vfwp

--- a/wp-content/plugins/vf-events/vf-events.php
+++ b/wp-content/plugins/vf-events/vf-events.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: VF-WP Events
 Description: VF-WP events custom post type and Gutenberg blocks.
-Version: 0.1.0
+Version: 1.0.0-beta.1
 Author: EMBL-EBI Web Development
 Plugin URI: https://github.com/visual-framework/vf-wp
 Text Domain: vfwp

--- a/wp-content/plugins/vf-example-block/index.php
+++ b/wp-content/plugins/vf-example-block/index.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: VF-WP Example
 Description: VF-WP theme block (developer example).
-Version: 0.1.2
+Version: 1.0.0-beta.1
 Author: EMBL-EBI Web Development
 Plugin URI: https://github.com/visual-framework/vf-wp
 Text Domain: vfwp

--- a/wp-content/plugins/vf-factoid-block/index.php
+++ b/wp-content/plugins/vf-factoid-block/index.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: VF-WP Factoid
 Description: VF-WP theme block.
-Version: 0.1.2
+Version: 1.0.0-beta.1
 Author: EMBL-EBI Web Development
 Plugin URI: https://github.com/visual-framework/vf-wp
 Text Domain: vfwp

--- a/wp-content/plugins/vf-global-footer-container/index.php
+++ b/wp-content/plugins/vf-global-footer-container/index.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: VF-WP Global Footer
 Description: VF-WP theme global container.
-Version: 0.1.2
+Version: 1.0.0-beta.1
 Author: EMBL-EBI Web Development
 Plugin URI: https://github.com/visual-framework/vf-wp
 Text Domain: vfwp

--- a/wp-content/plugins/vf-global-header-container/index.php
+++ b/wp-content/plugins/vf-global-header-container/index.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: VF-WP Global Header
 Description: VF-WP theme global container.
-Version: 0.1.2
+Version: 1.0.0-beta.1
 Author: EMBL-EBI Web Development
 Plugin URI: https://github.com/visual-framework/vf-wp
 Text Domain: vfwp

--- a/wp-content/plugins/vf-group-header-block/index.php
+++ b/wp-content/plugins/vf-group-header-block/index.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: VF-WP Group Header
 Description: VF-WP theme block.
-Version: 0.1.3
+Version: 1.0.0-beta.1
 Author: EMBL-EBI Web Development
 Plugin URI: https://github.com/visual-framework/vf-wp
 Text Domain: vfwp

--- a/wp-content/plugins/vf-gutenberg/vf-gutenberg.php
+++ b/wp-content/plugins/vf-gutenberg/vf-gutenberg.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: VF-WP Gutenberg
 Description: Adds Visual Framework support and blocks to the Gutenberg editor.
-Version: 0.2.0
+Version: 1.0.0-beta.1
 Author: EMBL-EBI Web Development
 Plugin URI: https://github.com/visual-framework/vf-wp
 Text Domain: vfwp

--- a/wp-content/plugins/vf-jobs-block/index.php
+++ b/wp-content/plugins/vf-jobs-block/index.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: VF-WP Jobs
 Description: VF-WP theme block.
-Version: 0.1.3
+Version: 1.0.0-beta.1
 Author: EMBL-EBI Web Development
 Plugin URI: https://github.com/visual-framework/vf-wp
 Text Domain: vfwp

--- a/wp-content/plugins/vf-latest-posts-block/index.php
+++ b/wp-content/plugins/vf-latest-posts-block/index.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: VF-WP Latest Posts (Deprecated)
 Description: VF-WP theme block.
-Version: 0.1.2
+Version: 1.0.0-beta.1
 Author: EMBL-EBI Web Development
 Plugin URI: https://github.com/visual-framework/vf-wp
 Text Domain: vfwp

--- a/wp-content/plugins/vf-members-block/index.php
+++ b/wp-content/plugins/vf-members-block/index.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: VF-WP Members
 Description: VF-WP theme block.
-Version: 0.1.3
+Version: 1.0.0-beta.1
 Author: EMBL-EBI Web Development
 Plugin URI: https://github.com/visual-framework/vf-wp
 Text Domain: vfwp

--- a/wp-content/plugins/vf-publications-block/index.php
+++ b/wp-content/plugins/vf-publications-block/index.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: VF-WP Publications
 Description: VF-WP theme block.
-Version: 0.1.3
+Version: 1.0.0-beta.1
 Author: EMBL-EBI Web Development
 Plugin URI: https://github.com/visual-framework/vf-wp
 Text Domain: vfwp

--- a/wp-content/plugins/vf-publications-group-ebi-block/index.php
+++ b/wp-content/plugins/vf-publications-group-ebi-block/index.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: VF-WP Publications Group EBI
 Description: Query for team publications based of EMBL-EBI specific data source (EBI Content Database).
-Version: 0.1.3
+Version: 1.0.0-beta.1
 Author: EMBL-EBI Web Development
 Plugin URI: https://github.com/visual-framework/vf-wp
 Text Domain: vfwp

--- a/wp-content/plugins/vf-wp/index.php
+++ b/wp-content/plugins/vf-wp/index.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: VF-WP
 Description: VF-WP theme plugin manager.
-Version: 0.2.0
+Version: 1.0.0-beta.1
 Author: EMBL-EBI Web Development
 Plugin URI: https://github.com/visual-framework/vf-wp
 Text Domain: vfwp

--- a/wp-content/themes/vf-wp-documents/style.css
+++ b/wp-content/themes/vf-wp-documents/style.css
@@ -2,9 +2,9 @@
 Theme Name:		 VF-WP Documents
 Theme URI:		 https://github.com/visual-framework/vf-wp/tree/master/wp-content/themes/vf-wp-documents/
 Description:	 Visual Framework WordPress Theme for EMBL Documents
-Author:			 Szymon Kasprzyk
-Template:		 vf-wp
-Version:		 1.0.0
+Author:        Szymon Kasprzyk
+Template:      vf-wp
+Version:       1.0.0-beta.1
 Text Domain:	 vfwp
 */
 

--- a/wp-content/themes/vf-wp-groups/style.css
+++ b/wp-content/themes/vf-wp-groups/style.css
@@ -4,6 +4,6 @@ Theme URI:    https://github.com/visual-framework/vf-wp/
 Description:  Visual Framework WordPress Theme for Groups
 Author:       EMBL
 Template:     vf-wp
-Version:      0.1.0
+Version:      1.0.0-beta.1
 Text Domain:  vfwp
 */

--- a/wp-content/themes/vf-wp-news/style.css
+++ b/wp-content/themes/vf-wp-news/style.css
@@ -1,11 +1,11 @@
-/* 
+/*
 Theme Name:		 vf-wp-news-main
 Theme URI:		 http://childtheme-generator.com/
 Description:	 vf-wp-news-main is a child theme of VF-WP, created by ChildTheme-Generator.com
-Author:			 Szymon Kasprzyk
+Author:        Szymon Kasprzyk
 Author URI:		 http://childtheme-generator.com/
-Template:		 vf-wp
-Version:		 1.0.0
+Template:      vf-wp
+Version:       1.0.0-beta.1
 Text Domain:	 vf-wp-news-main
 */
 

--- a/wp-content/themes/vf-wp/style.css
+++ b/wp-content/themes/vf-wp/style.css
@@ -3,6 +3,6 @@ Theme Name:   VF-WP
 Theme URI:    https://github.com/visual-framework/vf-wp/
 Description:  Visual Framework WordPress Theme
 Author:       EMBL
-Version:      0.3.0
+Version:      1.0.0-beta.1
 Text Domain:  vfwp
 */


### PR DESCRIPTION
Closes #235 

- Adds PUBLISHING.md
- Inits the version numbers on plugins and themes to all be v1.0.0-beta.1 
  (I think all plugins/themes are probably at least "beta quality" and we can bump things to stable, RC as appropriate in the future)