### PR TITLE
fix/issue-276

### DIFF
--- a/docs/wordpress.md
+++ b/docs/wordpress.md
@@ -27,6 +27,7 @@ In `wp_options` table set:
 | options_vf_cdn_stylesheet | [CDN URL] | no |
 | options_vf_cdn_javascript | [CDN URL] | no |
 | options_vf_api_url | [API URL] | no |
+| options_vf_cache_disabled | 0 | no |
 
 ### CDN and API URLs (examples):
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vf-wp",
-  "version": "1.0.0-beta.2",
+  "version": "1.0.0-beta.3",
   "private": true,
   "description": "Visual Framework WordPress Theme",
   "main": "gulpfile.js",

--- a/wp-content/plugins/vf-wp/index.php
+++ b/wp-content/plugins/vf-wp/index.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: VF-WP
 Description: VF-WP theme plugin manager.
-Version: 1.0.0-beta.1
+Version: 1.0.0-beta.2
 Author: EMBL-EBI Web Development
 Plugin URI: https://github.com/visual-framework/vf-wp
 Text Domain: vfwp

--- a/wp-content/plugins/vf-wp/vf-cache.php
+++ b/wp-content/plugins/vf-wp/vf-cache.php
@@ -45,6 +45,14 @@ class VF_Cache {
   }
 
   /**
+   * Return true if the cache is disabled
+   */
+  static public function is_disabled() {
+    $is_disabled = get_field('vf_cache_disabled', 'option');
+    return in_array($is_disabled, array(true, 1));
+  }
+
+  /**
    * Return the post modified age in seconds
    */
   static public function get_post_age($post) {
@@ -394,6 +402,10 @@ xhr.send('<?php echo build_query($data); ?>');
     );
 
     if (is_admin()) {
+      add_action(
+        'admin_notices',
+        array($this, 'admin_notices')
+      );
       add_filter(
         'manage_' . $this->post_type . '_posts_columns',
         array($this, 'manage_vf_cache_posts_columns'),
@@ -503,25 +515,64 @@ xhr.send('<?php echo build_query($data); ?>');
    * Add field for Content Hub API URL
    */
   public function acf_init() {
-    acf_add_local_field(
-      array(
-        'parent' => 'group_embl_setting',
-        'key' => 'field_vf_api_url',
-        'label' => __('EMBL Content Hub', 'vfwp'),
-        'name' => 'vf_api_url',
-        'type' => 'url',
-        'instructions' => '',
-        'required' => 0,
-        'conditional_logic' => 0,
-        'wrapper' => array(
-          'width' => '',
-          'class' => '',
-          'id' => '',
+    acf_add_local_field_group(array(
+      'key' => 'group_5eb28cf840399',
+      'title' => __('Cache Settings', 'vfwp'),
+      'fields' => array(
+        array(
+          'key' => 'field_vf_api_url',
+          'label' => __('EMBL Content Hub', 'vfwp'),
+          'name' => 'vf_api_url',
+          'type' => 'url',
+          'instructions' => '',
+          'required' => 0,
+          'conditional_logic' => 0,
+          'wrapper' => array(
+            'width' => '',
+            'class' => '',
+            'id' => '',
+          ),
+          'default_value' => '',
+          'placeholder' => '',
         ),
-        'default_value' => '',
-        'placeholder' => '',
-      )
-    );
+        array(
+          'key' => 'field_vf_cache_disabled',
+          'label' => __('Disable Cache', 'vfwp'),
+          'name' => 'vf_cache_disabled',
+          'type' => 'true_false',
+          'instructions' => __('Disable the Content Hub cache. This is not advised for live websites.', 'vfwp'),
+          'required' => 0,
+          'conditional_logic' => 0,
+          'wrapper' => array(
+            'width' => '',
+            'class' => '',
+            'id' => '',
+          ),
+          'message' => '',
+          'default_value' => 0,
+          'ui' => 1,
+          'ui_on_text' => '',
+          'ui_off_text' => '',
+        ),
+      ),
+      'location' => array(
+        array(
+          array(
+            'param' => 'options_page',
+            'operator' => '==',
+            'value' => 'vf-settings',
+          ),
+        ),
+      ),
+      'menu_order' => 100,
+      'position' => 'normal',
+      'style' => 'default',
+      'label_placement' => 'top',
+      'instruction_placement' => 'label',
+      'hide_on_screen' => '',
+      'active' => true,
+      'description' => '',
+    ));
   }
 
   /**
@@ -648,6 +699,31 @@ xhr.send('<?php echo build_query($data); ?>');
   function user_can_richedit($default) {
     if (get_post_type() === 'vf_cache') return false;
     return $default;
+  }
+
+  /**
+   * Add admin notice when cache is disabled
+   */
+  public function admin_notices() {
+    if ( ! function_exists('get_current_screen')) {
+      return;
+    }
+    $screen = get_current_screen();
+    if ($screen->id !== 'edit-vf_cache') {
+      return;
+    }
+
+    if (VF_Cache::is_disabled()) {
+      printf('<div class="%1$s"><p>%2$s %3$s</p></div>',
+        esc_attr('notice notice-error'),
+        esc_html__('The Content Hub cache is currently disabled', 'vfwp'),
+        ' <a href="'
+          . admin_url('admin.php?page=vf-settings')
+          . '" class="button button-small">'
+          . esc_html__('View Settings', 'vfwp')
+          . '</a>'
+      );
+    }
   }
 
 } // VF_Cache


### PR DESCRIPTION
Resolves #276

Adds an option to disabled and bypass the cache.

When enabled all Content Hub requests are made for every page load. Existing cache is ignored and not updated.

![cache-settings](https://user-images.githubusercontent.com/998922/81171586-24929100-8f8c-11ea-980a-be9215bbe645.png)

Can be set programmatically In `wp_options` table:

| option_name | option_value |
| ----------- | ------------ |
| options_vf_cache_disabled | 0 |

Change value to `1` to disable the cache (default is `0`).