### PR TITLE
BUG - Don't invoke emblNotifications manually

### DIFF
--- a/vf-components/vf-componenet-rollup/scripts.js
+++ b/vf-components/vf-componenet-rollup/scripts.js
@@ -14,7 +14,7 @@ import { vfMastheadSetStyle } from 'vf-masthead/vf-masthead';
 vfMastheadSetStyle();
 
 import { vfGaIndicateLoaded } from 'vf-analytics-google/vf-analytics-google';
-vfGaIndicateLoaded(); 
+vfGaIndicateLoaded();
 
 import { vfTabs } from 'vf-tabs/vf-tabs';
 vfTabs();
@@ -38,6 +38,5 @@ emblBreadcrumbs();
 import { emblContentMetaProperties_Read } from 'embl-content-meta-properties/embl-content-meta-properties';
 
 import { emblNotifications } from 'embl-notifications/embl-notifications';
-emblNotifications();
-
-// No default invokation
+// if you use embl-content-hub-loader, it will automatically invoke emblNotifications
+// emblNotifications();

--- a/wp-content/themes/vf-wp/assets/assets/vf-banner/vf-banner--alert.precompiled.js
+++ b/wp-content/themes/vf-wp/assets/assets/vf-banner/vf-banner--alert.precompiled.js
@@ -10,7 +10,7 @@ try {
 var parentTemplate = null;
 output += "<div class=\"vf-banner vf-banner--alert vf-banner--alert\">\n  <div class=\"vf-banner__content\">\n    <p class=\"vf-banner__text\">";
 output += runtime.suppressValue(runtime.contextOrFrameLookup(context, frame, "success_message"), env.opts.autoescape);
-output += "</p>\n    <button class=\"vf-button vf-button--icon vf-button--dismiss | vf-banner__button\">\n      <svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\"><title>close</title><path d=\"M14.3,12.179a.25.25,0,0,1,0-.354l9.263-9.262A1.5,1.5,0,0,0,21.439.442L12.177,9.7a.25.25,0,0,1-.354,0L2.561.442A1.5,1.5,0,0,0,.439,2.563L9.7,11.825a.25.25,0,0,1,0,.354L.439,21.442a1.5,1.5,0,0,0,2.122,2.121L11.823,14.3a.25.25,0,0,1,.354,0l9.262,9.263a1.5,1.5,0,0,0,2.122-2.121Z\"/></svg>\n    </button>\n  </div>\n</div>\n";
+output += "</p>\n    <button class=\"vf-button vf-button--icon vf-button--dismiss | vf-banner__button\">\n      <svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\"><title>dismiss banner</title><path d=\"M14.3,12.179a.25.25,0,0,1,0-.354l9.263-9.262A1.5,1.5,0,0,0,21.439.442L12.177,9.7a.25.25,0,0,1-.354,0L2.561.442A1.5,1.5,0,0,0,.439,2.563L9.7,11.825a.25.25,0,0,1,0,.354L.439,21.442a1.5,1.5,0,0,0,2.122,2.121L11.823,14.3a.25.25,0,0,1,.354,0l9.262,9.263a1.5,1.5,0,0,0,2.122-2.121Z\"/></svg>\n    </button>\n  </div>\n</div>\n";
 if(parentTemplate) {
 parentTemplate.rootRenderFunc(env, context, frame, runtime, cb);
 } else {

--- a/wp-content/themes/vf-wp/assets/assets/vf-banner/vf-banner--top.precompiled.js
+++ b/wp-content/themes/vf-wp/assets/assets/vf-banner/vf-banner--top.precompiled.js
@@ -8,7 +8,7 @@ var colno = 0;
 var output = "";
 try {
 var parentTemplate = null;
-output += "<div class=\"vf-banner vf-banner--fixed vf-banner--top vf-banner--phase\"\ndata-vf-js-banner\ndata-vf-js-banner-state=\"dismissible\"\ndata-vf-js-banner-button-text=\"Close notice\">\n  <div class=\"vf-banner__content\" data-vf-js-banner-text>\n    <span class=\"vf-badge vf-badge--primary\">BETA</span>\n    <p class=\"vf-banner__text\">This is the new EMBL.org <a href=\"";
+output += "<div class=\"vf-banner vf-banner--fixed vf-banner--top vf-banner--phase\"\ndata-vf-js-banner\ndata-vf-js-banner-state=\"dismissible\"\ndata-vf-js-banner-button-text=\"Close notice\"\ndata-vf-js-banner-button-theme=\"primary\">\n  <div class=\"vf-banner__content\" data-vf-js-banner-text>\n    <span class=\"vf-badge vf-badge--primary\">BETA</span>\n    <p class=\"vf-banner__text\">This is the new EMBL.org <a href=\"";
 output += runtime.suppressValue(runtime.contextOrFrameLookup(context, frame, "vf") - runtime.contextOrFrameLookup(context, frame, "banner") - -runtime.contextOrFrameLookup(context, frame, "inline__url"), env.opts.autoescape);
 output += "\" class=\"vf-banner__link\">Complete our quick survey</a> to help us make it better.</p>\n  </div>\n</div>\n";
 if(parentTemplate) {

--- a/wp-content/themes/vf-wp/assets/assets/vf-banner/vf-banner.css
+++ b/wp-content/themes/vf-wp/assets/assets/vf-banner/vf-banner.css
@@ -41,7 +41,7 @@
 
 /*!
  * Component: @visual-framework/vf-banner
- * Version: 1.0.6
+ * Version: 1.1.0
  * Location: components/vf-banner
  */
 .vf-banner {

--- a/wp-content/themes/vf-wp/assets/assets/vf-banner/vf-banner.js
+++ b/wp-content/themes/vf-wp/assets/assets/vf-banner/vf-banner.js
@@ -170,7 +170,18 @@ function vfBannerInsert(banner,bannerId,scope) {
   // if there is a vfJsBannerButtonText and banner is blocking or dismissible,
   // add a button so user can close the banner
   if (banner.vfJsBannerButtonText && (banner.vfJsBannerState === 'blocking' || banner.vfJsBannerState === 'dismissible')) {
-    generatedBannerHtml += '<button class="vf-button vf-button--secondary" data-vf-js-banner-close>'+banner.vfJsBannerButtonText+'</button>';
+    if (banner.vfJsBannerButtonTheme == 'primary') {
+      generatedBannerHtml += '<button class="vf-button vf-button--primary" data-vf-js-banner-close>'+banner.vfJsBannerButtonText+'</button>';
+    }
+    else if (banner.vfJsBannerButtonTheme == 'secondary') {
+      generatedBannerHtml += '<button class="vf-button vf-button--secondary" data-vf-js-banner-close>'+banner.vfJsBannerButtonText+'</button>';
+    }
+    else if (banner.vfJsBannerButtonTheme == 'tertiary') {
+      generatedBannerHtml += '<button class="vf-button vf-button--tertary" data-vf-js-banner-close>'+banner.vfJsBannerButtonText+'</button>';
+    }
+    else {
+      generatedBannerHtml += '<button class="vf-button vf-button--secondary" data-vf-js-banner-close>'+banner.vfJsBannerButtonText+'</button>';
+    }
   }
 
   generatedBannerHtml += '</div>';

--- a/wp-content/themes/vf-wp/assets/assets/vf-card-container/vf-card-container.css
+++ b/wp-content/themes/vf-wp/assets/assets/vf-card-container/vf-card-container.css
@@ -41,7 +41,7 @@
 
 /*!
  * Component: @visual-framework/vf-card-container
- * Version: 1.0.0-alpha.4
+ * Version: 1.0.0
  * Location: components/vf-card-container
  */
 .vf-card-container {

--- a/wp-content/themes/vf-wp/assets/assets/vf-componenet-rollup/scripts.js
+++ b/wp-content/themes/vf-wp/assets/assets/vf-componenet-rollup/scripts.js
@@ -14,7 +14,7 @@ import { vfMastheadSetStyle } from 'vf-masthead/vf-masthead';
 vfMastheadSetStyle();
 
 import { vfGaIndicateLoaded } from 'vf-analytics-google/vf-analytics-google';
-vfGaIndicateLoaded(); 
+vfGaIndicateLoaded();
 
 import { vfTabs } from 'vf-tabs/vf-tabs';
 vfTabs();
@@ -38,6 +38,5 @@ emblBreadcrumbs();
 import { emblContentMetaProperties_Read } from 'embl-content-meta-properties/embl-content-meta-properties';
 
 import { emblNotifications } from 'embl-notifications/embl-notifications';
-emblNotifications();
-
-// No default invokation
+// if you use embl-content-hub-loader, it will automatically invoke emblNotifications
+// emblNotifications();

--- a/wp-content/themes/vf-wp/assets/assets/vf-content/vf-content.css
+++ b/wp-content/themes/vf-wp/assets/assets/vf-content/vf-content.css
@@ -1411,7 +1411,7 @@ html:not(.vf-disable-deprecated) .vf-text-button--1 {
 
 /*!
  * Component: @visual-framework/vf-content
- * Version: 1.1.3
+ * Version: 1.1.4
  * Location: components/vf-content
  */
 .vf-content h1:not([class*='vf-']) {
@@ -1663,12 +1663,12 @@ html:not(.vf-disable-deprecated) .vf-text-button--1 {
   margin-bottom: 32px;
 }
 
-.vf-content .vf-figure--float-inline-start {
+.vf-content .vf-figure--align-inline-start {
   margin-bottom: 32px;
   margin-right: 32px;
 }
 
-.vf-content .vf-figure--float-inline-end {
+.vf-content .vf-figure--align-inline-end {
   margin-bottom: 32px;
   margin-left: 32px;
 }

--- a/wp-content/themes/vf-wp/assets/assets/vf-header/vf-header--inlay.precompiled.js
+++ b/wp-content/themes/vf-wp/assets/assets/vf-header/vf-header--inlay.precompiled.js
@@ -11,7 +11,7 @@ var parentTemplate = null;
 output += "<style>\n:root {\n  /* These CSS properties are theming variables. If used, add to your HTML\n     after the VF CSS for vf-masthead and before the HTML for vf-masthead. */\n  --vf-masthead__bg-image: url('";
 output += runtime.suppressValue(env.getFilter("path").call(context, "../../assets/vf-masthead/assets/group-bg_2d4155.png"), env.opts.autoescape);
 output += "');\n}\n</style>\n\n<header class=\"vf-header vf-header--inlay\">\n\n";
-env.getExtension("render")["run"](context,"@vf-masthead--inlay", function(t_2,t_1) {
+env.getExtension("render")["run"](context,"@vf-masthead", function(t_2,t_1) {
 if(t_2) { cb(t_2); return; }
 output += runtime.suppressValue(t_1, true && env.opts.autoescape);
 env.getExtension("render")["run"](context,"@vf-navigation--main", function(t_4,t_3) {

--- a/wp-content/themes/vf-wp/assets/assets/vf-header/vf-header.css
+++ b/wp-content/themes/vf-wp/assets/assets/vf-header/vf-header.css
@@ -314,7 +314,7 @@
 
 /*!
  * Component: @visual-framework/vf-header
- * Version: 1.0.0-rc.2
+ * Version: 1.0.0
  * Location: components/vf-header
  */
 .vf-header {

--- a/wp-content/themes/vf-wp/assets/scripts/scripts.js
+++ b/wp-content/themes/vf-wp/assets/scripts/scripts.js
@@ -165,7 +165,15 @@ function vfBannerInsert(banner, bannerId, scope) {
 
 
   if (banner.vfJsBannerButtonText && (banner.vfJsBannerState === 'blocking' || banner.vfJsBannerState === 'dismissible')) {
-    generatedBannerHtml += '<button class="vf-button vf-button--secondary" data-vf-js-banner-close>' + banner.vfJsBannerButtonText + '</button>';
+    if (banner.vfJsBannerButtonTheme == 'primary') {
+      generatedBannerHtml += '<button class="vf-button vf-button--primary" data-vf-js-banner-close>' + banner.vfJsBannerButtonText + '</button>';
+    } else if (banner.vfJsBannerButtonTheme == 'secondary') {
+      generatedBannerHtml += '<button class="vf-button vf-button--secondary" data-vf-js-banner-close>' + banner.vfJsBannerButtonText + '</button>';
+    } else if (banner.vfJsBannerButtonTheme == 'tertiary') {
+      generatedBannerHtml += '<button class="vf-button vf-button--tertary" data-vf-js-banner-close>' + banner.vfJsBannerButtonText + '</button>';
+    } else {
+      generatedBannerHtml += '<button class="vf-button vf-button--secondary" data-vf-js-banner-close>' + banner.vfJsBannerButtonText + '</button>';
+    }
   }
 
   generatedBannerHtml += '</div>'; // set the html of the banner
@@ -1881,5 +1889,5 @@ vfGaIndicateLoaded();
 vfTabs();
 vfFormFloatLabels();
 emblContentHub();
-emblBreadcrumbs();
-emblNotifications(); // No default invokation
+emblBreadcrumbs(); // if you use embl-content-hub-loader, it will automatically invoke emblNotifications
+// emblNotifications();

--- a/wp-content/themes/vf-wp/assets/scripts/scripts.modern.js
+++ b/wp-content/themes/vf-wp/assets/scripts/scripts.modern.js
@@ -14,7 +14,7 @@ import { vfMastheadSetStyle } from 'vf-masthead/vf-masthead';
 vfMastheadSetStyle();
 
 import { vfGaIndicateLoaded } from 'vf-analytics-google/vf-analytics-google';
-vfGaIndicateLoaded(); 
+vfGaIndicateLoaded();
 
 import { vfTabs } from 'vf-tabs/vf-tabs';
 vfTabs();
@@ -38,6 +38,5 @@ emblBreadcrumbs();
 import { emblContentMetaProperties_Read } from 'embl-content-meta-properties/embl-content-meta-properties';
 
 import { emblNotifications } from 'embl-notifications/embl-notifications';
-emblNotifications();
-
-// No default invokation
+// if you use embl-content-hub-loader, it will automatically invoke emblNotifications
+// emblNotifications();


### PR DESCRIPTION
if you use embl-content-hub-loader, it will automatically invoke emblNotifications.

Fixes the issue of two notification banners spotted by @sturobson  and Filipe on slack.

aside: we'll eventually add logic to emblNotifications to check for double invocations, but you know, time. 