### PR TITLE
Chore/3 column archives

### DIFF
--- a/wp-content/themes/vf-wp-news/archive.php
+++ b/wp-content/themes/vf-wp-news/archive.php
@@ -33,7 +33,7 @@ if (is_search()) {
         <h1 class="vf-text vf-text-heading--1 | vf-u-margin__bottom--xl" style="font-weight: 400;">
         <?php single_tag_title(); ?></h1>
       </div>
-      <div class="vf-grid vf-grid__col-2">
+      <div class="vf-grid vf-grid__col-3">
         <?php if ( have_posts() ) : while ( have_posts() ) : the_post();
 if ( $post->ID == $do_not_duplicate ) continue; ?>
         <?php include(locate_template('partials/vf-card--article.php', false, false)); ?>

--- a/wp-content/themes/vf-wp-news/author.php
+++ b/wp-content/themes/vf-wp-news/author.php
@@ -52,7 +52,7 @@ if (is_search()) {
       <div>
         <h3 class="vf-section-header__heading vf-u-margin__bottom--xl">Articles by <?php the_author(); ?></h3>
       </div>
-      <div class="vf-grid | vf-grid__col-2">
+      <div class="vf-grid | vf-grid__col-3">
         <?php $page = (get_query_var('paged')) ? get_query_var('paged') : 1;
 				$args = array(
     			'posts_per_page' => 6,

--- a/wp-content/themes/vf-wp-news/category.php
+++ b/wp-content/themes/vf-wp-news/category.php
@@ -34,7 +34,7 @@ $category_name = single_cat_title("", false);
         <h2 class="vf-text vf-text-heading--1 | vf-u-margin__bottom--xl" style="font-weight: 400;">
         <?php echo esc_html($category_name) ?></h2>
       </div>
-      <div class="vf-grid vf-grid__col-2">
+      <div class="vf-grid vf-grid__col-3">
         <?php if ( have_posts() ) : while ( have_posts() ) : the_post();
 if ( $post->ID == $do_not_duplicate ) continue; ?>
         <?php include(locate_template('partials/vf-card--article.php', false, false)); ?>

--- a/wp-content/themes/vf-wp-news/page-archive.php
+++ b/wp-content/themes/vf-wp-news/page-archive.php
@@ -14,7 +14,7 @@ the_post();
         <h3 class="vf-text vf-text-heading--1 | vf-u-margin__bottom--xl" style="font-weight: 400;">
           <?php wp_title(''); ?></h3>
       </div>
-      <div class="vf-grid vf-grid__col-2">
+      <div class="vf-grid vf-grid__col-3">
         <?php $page = (get_query_var('paged')) ? get_query_var('paged') : 1;
 $args = array(
     'posts_per_page' => 10,


### PR DESCRIPTION
The two-column layout in the archive pages of the news theme makes Design's life harder due to the long aspect ratio. Using a three-column layout will save them time and allow better visuals, and makes a layout more consistent with the embl.org homepage.

Currently:

![image](https://user-images.githubusercontent.com/928100/89395399-8e4a4480-d70d-11ea-9403-7354757df29a.png)


After:

![image](https://user-images.githubusercontent.com/928100/89395373-84c0dc80-d70d-11ea-944a-3095dc475d27.png)
