### PR TITLE
enhancement/news container additional customisation

### DIFF
--- a/wp-content/plugins/vf-embl-news-container/group_vf_embl_news.json
+++ b/wp-content/plugins/vf-embl-news-container/group_vf_embl_news.json
@@ -3,6 +3,60 @@
     "title": "VF EMBL News (container)",
     "fields": [
         {
+            "key": "field_5f52159c34be5",
+            "label": "Heading",
+            "name": "vf_embl_news_heading",
+            "type": "text",
+            "instructions": "By default the heading reads 'Latest news'",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "33",
+                "class": "",
+                "id": ""
+            },
+            "default_value": "",
+            "placeholder": "",
+            "prepend": "",
+            "append": "",
+            "maxlength": ""
+        },
+        {
+            "key": "field_5f5215b334be6",
+            "label": "Link",
+            "name": "vf_embl_news_link",
+            "type": "url",
+            "instructions": "By default the heading is linked to the embl.org/news",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "33",
+                "class": "",
+                "id": ""
+            },
+            "default_value": "",
+            "placeholder": ""
+        },
+        {
+            "key": "field_5f5215d534be7",
+            "label": "Additional text",
+            "name": "vf_embl_news_additional_text",
+            "type": "text",
+            "instructions": "Optional",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "33",
+                "class": "",
+                "id": ""
+            },
+            "default_value": "",
+            "placeholder": "",
+            "prepend": "",
+            "append": "",
+            "maxlength": ""
+        },
+        {
             "key": "field_vf_embl_news_limit",
             "label": "Display",
             "name": "vf_embl_news_limit",
@@ -11,16 +65,35 @@
             "required": 0,
             "conditional_logic": 0,
             "wrapper": {
-                "width": "",
+                "width": "50",
                 "class": "",
                 "id": ""
             },
-            "default_value": "3",
+            "default_value": 3,
             "min": 1,
             "max": 10,
             "step": "",
             "prepend": "",
             "append": ""
+        },
+        {
+            "key": "field_5f52164f0c3d1",
+            "label": "Enable sidebar",
+            "name": "vf_embl_news_enable_sidebar",
+            "type": "true_false",
+            "instructions": "To add content to the sidebar go to Appearance > Widgets, and drag and drop available widgets under 'EMBL News container'",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "50",
+                "class": "",
+                "id": ""
+            },
+            "message": "",
+            "default_value": 0,
+            "ui": 1,
+            "ui_on_text": "",
+            "ui_off_text": ""
         },
         {
             "key": "field_vf_embl_news_keyword",
@@ -31,7 +104,7 @@
             "required": 0,
             "conditional_logic": 0,
             "wrapper": {
-                "width": "",
+                "width": "50",
                 "class": "",
                 "id": ""
             },
@@ -57,7 +130,7 @@
     "label_placement": "top",
     "instruction_placement": "label",
     "hide_on_screen": "",
-    "active": 1,
+    "active": true,
     "description": "",
-    "modified": 1544084692
+    "modified": 1599215396
 }

--- a/wp-content/plugins/vf-embl-news-container/index.php
+++ b/wp-content/plugins/vf-embl-news-container/index.php
@@ -46,23 +46,19 @@ class VF_EMBL_News extends VF_Plugin {
    * Cannot run on `acf/init` because taxonomy is not registered
    */
   function add_taxonomy_fields() {
-    // Add filter based on EMBL Taxonomy terms
-
-    /**
-     * Code Commented based on requirement of https://gitlab.ebi.ac.uk/emblorg/backlog/issues/173
 
     if (function_exists('embl_taxonomy')) {
       acf_add_local_field(
         array(
           'parent' => 'group_vf_embl_news',
           'key' => 'field_vf_embl_news_term',
-          'label' => __('Topic', 'vfwp'),
+          'label' => __('EMBL Taxonomy', 'vfwp'),
           'name' => 'vf_embl_news_term',
           'type' => 'taxonomy',
           'instructions' => __('Filter articles by this term – takes priority over <b>Keyword</b>.', 'vfwp'),
           'required' => 0,
           'wrapper' => array(
-            'width' => '',
+            'width' => '50',
             'class' => '',
             'id' => '',
           ),
@@ -77,36 +73,7 @@ class VF_EMBL_News extends VF_Plugin {
         )
       );
     }
-    */
-
-
-    // Add Factoid clone field
-    if (class_exists('VF_Factoid')) {
-      acf_add_local_field(
-        array(
-          'parent' => 'group_vf_embl_news',
-          'key' => 'field_vf_embl_news_factoid',
-          'label' => 'Factoid',
-          'name' => 'vf_embl_news_factoid',
-          'type' => 'clone',
-          'instructions' => '',
-          'required' => 0,
-          'conditional_logic' => 0,
-          'wrapper' => array(
-            'width' => '',
-            'class' => '',
-            'id' => '',
-          ),
-          'clone' => array(
-            0 => 'group_vf_factoid',
-          ),
-          'display' => 'group',
-          'layout' => 'block',
-          'prefix_label' => 0,
-          'prefix_name' => 0,
-        )
-      );
-    }
+    
   }
 
 } // VF_EMBL_News

--- a/wp-content/plugins/vf-embl-news-container/template.php
+++ b/wp-content/plugins/vf-embl-news-container/template.php
@@ -69,24 +69,56 @@ $content = preg_replace(
   $content
 );
 
+$enable_sidebar = get_field('vf_embl_news_enable_sidebar');
+$heading = get_field('vf_embl_news_heading');
+$link = get_field('vf_embl_news_link');
+$additional_text = get_field('vf_embl_news_additional_text');
+$embl_grid = 'embl-grid';
+if ($enable_sidebar == 1) {
+  $embl_grid .= ' embl-grid--has-sidebar';
+}
 ?>
-<hr class="vf-divider">
-<div class="vf-u-grid--reset vf-body vf-body__additional-content vf-u-background-color-ui--white">
-  <section class="vf-news-container | embl-grid embl-grid--has-sidebar">
+  <section class="<?php echo $embl_grid; ?>">
     <div class="vf-section-header">
-      <h2 class="vf-section-header__heading"><?php the_title(); ?></h2>
+      <a class="vf-section-header__heading vf-section-header__heading--is-link" href="
+      <?php 
+      if (! empty($link)){
+        echo esc_url($link); }
+        else {
+          echo 'https://www.embl.org/news';
+        } ?>
+      ">
+
+      <?php 
+      if (! empty($heading)){
+        echo ($heading); }
+        else {
+          echo 'Latest news';
+      } ?>
+        <svg aria-hidden="true" class="vf-section-header__icon | vf-icon vf-icon-arrow--inline-end" width="24"
+          height="24" xmlns="http://www.w3.org/2000/svg">
+          <path
+            d="M0 12c0 6.627 5.373 12 12 12s12-5.373 12-12S18.627 0 12 0C5.376.008.008 5.376 0 12zm13.707-5.209l4.5 4.5a1 1 0 010 1.414l-4.5 4.5a1 1 0 01-1.414-1.414l2.366-2.367a.25.25 0 00-.177-.424H6a1 1 0 010-2h8.482a.25.25 0 00.177-.427l-2.366-2.368a1 1 0 011.414-1.414z"
+            fill="" fill-rule="nonzero">
+          </path>
+        </svg>
+      </a>
+      <?php if ($additional_text) { ?>
+      <p class="vf-section-header__text">
+        <?php echo $additional_text; ?>
+      </p>
+      <?php } ?>
     </div>
-    <?php echo $content; ?>
-    <div class="vf-news-container__sidebar">
-      <?php
-      if (class_exists('VF_Factoid')) {
-        $vf_factoid = VF_Plugin::get_plugin('vf_factoid');
-        $fields = get_field('vf_embl_news_factoid', $acf_id);
-        if (is_array($fields)) {
-          VF_Plugin::render($vf_factoid, $fields, $vf_plugin);
-        }
-      }
-      ?>
+    <div>
+      <?php echo $content; ?>
     </div>
+    
+    <?php 
+    if ($enable_sidebar == 1) {
+    if (is_active_sidebar('vf_wp_embl_news_container')) { ?>
+    <div>
+      <?php vf_sidebar('vf_wp_embl_news_container'); ?>
+    </div>
+    <?php }} ?>
+
   </section>
-</div>

--- a/wp-content/themes/vf-wp/blocks/vfwp-links-list/widget.php
+++ b/wp-content/themes/vf-wp/blocks/vfwp-links-list/widget.php
@@ -50,9 +50,6 @@ if ($type === 'easy' || $type === 'very-easy' || $type === 'has-image') {
   $class_div .= " vf-links__list--{$type}";
 }
 
-echo $before_widget;
-
-
 ?>
 <div class="<?php echo esc_attr($class_div); ?>">
   <?php if ( ! empty($heading)) { ?>
@@ -111,7 +108,7 @@ echo $before_widget;
 
     </li>
     <!--/vf-list-item-->
-      <?php 	echo $before_widget;
+      <?php
  } ?>
   </ul>
 </div>

--- a/wp-content/themes/vf-wp/functions/theme-widgets.php
+++ b/wp-content/themes/vf-wp/functions/theme-widgets.php
@@ -129,8 +129,13 @@ class VF_Theme_Widgets {
         'name'          => __('Page Sidebar', 'vfwp'),
         'id'            => 'sidebar-page',
         'description'   => __( 'Sidebar for standard pages.', 'vfwp')
-      ))
-    );
+      )),
+    array_merge($defaults, array(
+      'name'          => __('EMBL News container', 'vfwp'),
+      'id'            => 'vf_wp_embl_news_container',
+      'description'   => __( 'Sidebar for EMBL News container.', 'vfwp')
+    ))
+  );
     return $sidebars;
   }
 


### PR DESCRIPTION
This: 
- adds a sidebar to the embl news container and enables using widgets
- enables EMBL Taxonomy
- allows to customise the section header
- replaces `vf-inlay` grid with `embl-grid`
- issue #473 