### PR TITLE
Add support for ACF Inner Blocks

### DIFF
--- a/vf-components/vf-local-overrides/vf-local-overrides.scss
+++ b/vf-components/vf-local-overrides/vf-local-overrides.scss
@@ -7,8 +7,7 @@
 // If you don't have any Sass, you can trim this block down to:
 // "This page was intentionally left blank"
 
-
-@import 'vf-local-overrides.variables.scss';
+@import "vf-local-overrides.variables.scss";
 
 .vf-local-overrides {
   /* your settings here */
@@ -21,7 +20,6 @@
 }
 
 .vf-box__text {
-
   // some times there's a link inside the text in old WP posts.
   // the vf-box might also be inside of `vf-content`
   .vf-content & a,
@@ -34,7 +32,7 @@
   }
 }
 
-  // WordPress is adding a figure around tables and we get default margins
-  figure:not([class*="vf-"]) {
-    margin: 0;
-  }
+// WordPress is adding a figure around tables and we get default margins
+figure:not([class*="vf-"]) {
+  margin: 0;
+}

--- a/vf-components/vfwp-admin/vfwp-admin.css
+++ b/vf-components/vfwp-admin/vfwp-admin.css
@@ -52,112 +52,327 @@
 
 /* stylelint-enable */
 /*!
- * Component: @visual-framework/vf-font-plex-sans
- * Version: 1.1.0
+ * Component: @visual-framework/vf-content
+ * Version: 1.2.2
  * Location: components/vf-core-
  */
-@font-face {
-  font-family: "IBM Plex Sans";
-  font-style: normal;
-  font-weight: 700;
-  src: local("IBM Plex Sans Bold"), local("IBMPlexSans-Bold"), url("../assets/vf-font-plex-sans/assets/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-Bold.woff") format("woff");
-}
-@font-face {
-  font-family: "IBM Plex Sans";
-  font-style: italic;
-  font-weight: 700;
-  src: local("IBM Plex Sans Bold Italic"), local("IBMPlexSans-BoldItalic"), url("../assets/vf-font-plex-sans/assets/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-BoldItalic.woff") format("woff");
-}
-@font-face {
-  font-family: "IBM Plex Sans";
-  font-style: normal;
-  font-weight: 200;
-  src: local("IBM Plex Sans ExtraLight"), local("IBMPlexSans-ExtraLight"), url("../assets/vf-font-plex-sans/assets/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-ExtraLight.woff") format("woff");
-}
-@font-face {
-  font-family: "IBM Plex Sans";
-  font-style: italic;
-  font-weight: 200;
-  src: local("IBM Plex Sans ExtraLight Italic"), local("IBMPlexSans-ExtraLightItalic"), url("../assets/vf-font-plex-sans/assets/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-ExtraLightItalic.woff") format("woff");
-}
-@font-face {
-  font-family: "IBM Plex Sans";
-  font-style: italic;
-  font-weight: 400;
-  src: local("IBM Plex Sans Italic"), local("IBMPlexSans-Italic"), url("../assets/vf-font-plex-sans/assets/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-Italic.woff") format("woff");
-}
-@font-face {
-  font-family: "IBM Plex Sans";
-  font-style: normal;
-  font-weight: 300;
-  src: local("IBM Plex Sans Light"), local("IBMPlexSans-Light"), url("../assets/vf-font-plex-sans/assets/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-Light.woff") format("woff");
-}
-@font-face {
-  font-family: "IBM Plex Sans";
-  font-style: italic;
-  font-weight: 300;
-  src: local("IBM Plex Sans Light Italic"), local("IBMPlexSans-LightItalic"), url("../assets/vf-font-plex-sans/assets/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-LightItalic.woff") format("woff");
-}
-@font-face {
-  font-family: "IBM Plex Sans";
-  font-style: normal;
-  font-weight: 500;
-  src: local("IBM Plex Sans Medium"), local("IBMPlexSans-Medium"), url("../assets/vf-font-plex-sans/assets/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-Medium.woff") format("woff");
-}
-@font-face {
-  font-family: "IBM Plex Sans";
-  font-style: italic;
-  font-weight: 500;
-  src: local("IBM Plex Sans Medium Italic"), local("IBMPlexSans-MediumItalic"), url("../assets/vf-font-plex-sans/assets/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-MediumItalic.woff") format("woff");
-}
-@font-face {
-  font-family: "IBM Plex Sans";
-  font-style: normal;
-  font-weight: 400;
-  src: local("IBM Plex Sans"), local("IBMPlexSans"), url("../assets/vf-font-plex-sans/assets/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-Regular.woff") format("woff");
-}
-@font-face {
-  font-family: "IBM Plex Sans";
-  font-style: normal;
-  font-weight: 600;
-  src: local("IBM Plex Sans SemiBold"), local("IBMPlexSans-SemiBold"), url("../assets/vf-font-plex-sans/assets/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-SemiBold.woff") format("woff");
-}
-@font-face {
-  font-family: "IBM Plex Sans";
-  font-style: italic;
-  font-weight: 600;
-  src: local("IBM Plex Sans SemiBold Italic"), local("IBMPlexSans-SemiBoldItalic"), url("../assets/vf-font-plex-sans/assets/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-SemiBoldItalic.woff") format("woff");
-}
-@font-face {
-  font-family: "IBM Plex Sans";
-  font-style: normal;
-  font-weight: 450;
-  src: local("IBM Plex Sans Text"), local("IBMPlexSans-Text"), url("../assets/vf-font-plex-sans/assets/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-Text.woff") format("woff");
-}
-@font-face {
-  font-family: "IBM Plex Sans";
-  font-style: italic;
-  font-weight: 450;
-  src: local("IBM Plex Sans Text Italic"), local("IBMPlexSans-TextItalic"), url("../assets/vf-font-plex-sans/assets/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-TextItalic.woff") format("woff");
-}
-@font-face {
-  font-family: "IBM Plex Sans";
-  font-style: normal;
-  font-weight: 100;
-  src: local("IBM Plex Sans Thin"), local("IBMPlexSans-Thin"), url("../assets/vf-font-plex-sans/assets/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-Thin.woff") format("woff");
-}
-@font-face {
-  font-family: "IBM Plex Sans";
-  font-style: italic;
-  font-weight: 100;
-  src: local("IBM Plex Sans Thin Italic"), local("IBMPlexSans-ThinItalic"), url("../assets/vf-font-plex-sans/assets/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-ThinItalic.woff") format("woff");
-}
-.vf-font-plex-sans {
+.vf-content h1:not([class*=vf-]), .editor-styles-wrapper h1:not([class*=vf-]) {
   font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
-  font-size: 16px;
-  font-weight: 400;
-  line-height: 1.71;
+  font-size: 42px;
+  font-weight: 700;
+  line-height: 1.547;
   margin: 0 0 0 0;
+}
+.vf-content h1:not([class*=vf-]) + small, .editor-styles-wrapper h1:not([class*=vf-]) + small {
+  margin-bottom: 35px;
+  margin-top: 22px;
+}
+.vf-content h1:not([class*=vf-]) b, .editor-styles-wrapper h1:not([class*=vf-]) b,
+.vf-content h1:not([class*=vf-]) strong,
+.editor-styles-wrapper h1:not([class*=vf-]) strong {
+  font-weight: inherit;
+}
+.vf-content h2:not([class*=vf-]), .editor-styles-wrapper h2:not([class*=vf-]) {
+  font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
+  font-size: 30px;
+  font-weight: 500;
+  line-height: 1.333;
+  margin: 0 0 39px 0;
+  margin-top: 0;
+  padding-top: 13px;
+}
+.vf-content h2:not([class*=vf-]) b, .editor-styles-wrapper h2:not([class*=vf-]) b,
+.vf-content h2:not([class*=vf-]) strong,
+.editor-styles-wrapper h2:not([class*=vf-]) strong {
+  font-weight: inherit;
+}
+.vf-content h3:not([class*=vf-]), .editor-styles-wrapper h3:not([class*=vf-]) {
+  font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
+  font-size: 24px;
+  font-weight: 500;
+  line-height: 1.333;
+  margin: 0 0 13px 0;
+  margin-top: 24px;
+}
+.vf-content h3:not([class*=vf-]) b, .editor-styles-wrapper h3:not([class*=vf-]) b,
+.vf-content h3:not([class*=vf-]) strong,
+.editor-styles-wrapper h3:not([class*=vf-]) strong {
+  font-weight: inherit;
+}
+.vf-content h4:not([class*=vf-]), .editor-styles-wrapper h4:not([class*=vf-]) {
+  font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
+  font-size: 21px;
+  font-weight: 500;
+  line-height: 1.29;
+  margin: 0 0 13px 0;
+  margin-top: 24px;
+}
+.vf-content h4:not([class*=vf-]) b, .editor-styles-wrapper h4:not([class*=vf-]) b,
+.vf-content h4:not([class*=vf-]) strong,
+.editor-styles-wrapper h4:not([class*=vf-]) strong {
+  font-weight: inherit;
+}
+.vf-content h5:not([class*=vf-]), .editor-styles-wrapper h5:not([class*=vf-]) {
+  font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
+  font-size: 19px;
+  font-weight: 500;
+  line-height: 1.5;
+  margin: 0 0 13px 0;
+  margin-top: 24px;
+}
+.vf-content h5:not([class*=vf-]) b, .editor-styles-wrapper h5:not([class*=vf-]) b,
+.vf-content h5:not([class*=vf-]) strong,
+.editor-styles-wrapper h5:not([class*=vf-]) strong {
+  font-weight: inherit;
+}
+.vf-content h6:not([class*=vf-]), .editor-styles-wrapper h6:not([class*=vf-]) {
+  font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
+  font-size: 19px;
+  font-weight: 500;
+  line-height: 1.5;
+  margin: 0 0 13px 0;
+  margin-top: 24px;
+}
+.vf-content h6:not([class*=vf-]) b, .editor-styles-wrapper h6:not([class*=vf-]) b,
+.vf-content h6:not([class*=vf-]) strong,
+.editor-styles-wrapper h6:not([class*=vf-]) strong {
+  font-weight: inherit;
+}
+.vf-content p:not([class*=vf-]), .editor-styles-wrapper p:not([class*=vf-]) {
+  font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
+  font-size: 19px;
+  font-weight: 400;
+  line-height: 1.421;
+  margin: 0 0 24px 0;
+}
+.vf-content .vf-link, .editor-styles-wrapper .vf-link,
+.vf-content a:not([class*=vf-]),
+.editor-styles-wrapper a:not([class*=vf-]) {
+  border-bottom: none;
+  text-decoration: none;
+  color: #3b6fb6;
+}
+.vf-content .vf-link:visited, .editor-styles-wrapper .vf-link:visited,
+.vf-content a:not([class*=vf-]):visited,
+.editor-styles-wrapper a:not([class*=vf-]):visited {
+  color: #734595;
+  border-bottom: none;
+}
+.vf-content .vf-link:visited:hover, .editor-styles-wrapper .vf-link:visited:hover,
+.vf-content a:not([class*=vf-]):visited:hover,
+.editor-styles-wrapper a:not([class*=vf-]):visited:hover {
+  color: #734595;
+  text-decoration: underline;
+}
+.vf-content .vf-link:hover, .editor-styles-wrapper .vf-link:hover,
+.vf-content a:not([class*=vf-]):hover,
+.editor-styles-wrapper a:not([class*=vf-]):hover {
+  color: #193f90;
+  border-bottom: none;
+  text-decoration: underline;
+}
+.vf-content small:not([class*=vf-]), .editor-styles-wrapper small:not([class*=vf-]) {
+  font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 1.57;
+  margin: 0 0 16px 0;
+  margin: 0 0 var(--vf-text-margin--bottom, 16px) 0;
+  display: block;
+}
+.vf-content ol:not([class*=vf-]), .editor-styles-wrapper ol:not([class*=vf-]) {
+  margin: 0;
+  list-style-type: decimal;
+  padding-left: 16px;
+  padding-left: 20px;
+}
+.vf-list--ordered__item {
+  margin-bottom: 16px;
+}
+
+.vf-content ul:not([class*=vf-]), .editor-styles-wrapper ul:not([class*=vf-]) {
+  margin: 0;
+  padding-left: 16px;
+  list-style-type: disc;
+  padding-left: 20px;
+}
+.vf-list--unordered__item {
+  margin-bottom: 16px;
+}
+
+.vf-content li:not([class*=vf-]), .editor-styles-wrapper li:not([class*=vf-]) {
+  font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
+  font-size: 19px;
+  font-weight: 400;
+  line-height: 1.421;
+  margin: 0 0 16px 0;
+  margin: 0 0 var(--vf-text-margin--bottom, 16px) 0;
+  margin-bottom: 8px;
+}
+.vf-content li:not([class*=vf-]) > ul:not([class*=vf-]), .editor-styles-wrapper li:not([class*=vf-]) > ul:not([class*=vf-]),
+.vf-content li:not([class*=vf-]) > ol:not([class*=vf-]),
+.editor-styles-wrapper li:not([class*=vf-]) > ol:not([class*=vf-]) {
+  margin-top: 8px;
+}
+.vf-content li:not([class*=vf-]):last-of-type, .editor-styles-wrapper li:not([class*=vf-]):last-of-type {
+  margin-bottom: 16px;
+}
+.vf-content hr:not([class*=vf-]), .editor-styles-wrapper hr:not([class*=vf-]) {
+  background-color: #d8d8d8;
+  margin: 0 8px;
+  height: 1px;
+  border: none;
+}
+.vf-content code:not([class*=vf-]), .editor-styles-wrapper code:not([class*=vf-]) {
+  padding-left: 3px;
+  padding-right: 3px;
+}
+.vf-content blockquote:not([class*=vf-]), .editor-styles-wrapper blockquote:not([class*=vf-]) {
+  font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
+  font-size: 19px;
+  font-weight: 400;
+  line-height: 1.421;
+  margin: 0 0 16px 0;
+  margin: 0 0 var(--vf-text-margin--bottom, 16px) 0;
+  margin: 0 0 0 0;
+  border: 0;
+  padding: 10px 8px 10px 32px;
+  position: relative;
+}
+.vf-content blockquote:not([class*=vf-])::before, .editor-styles-wrapper blockquote:not([class*=vf-])::before {
+  content: "";
+  border-left: 4px solid #d0d0ce;
+  position: absolute;
+  left: 12px;
+  height: 100%;
+  top: 0;
+}
+.vf-content blockquote:not([class*=vf-]) p:last-of-type:not([class*=vf-]), .editor-styles-wrapper blockquote:not([class*=vf-]) p:last-of-type:not([class*=vf-]) {
+  margin-bottom: 0;
+}
+.vf-content table:not([class*=vf-]), .editor-styles-wrapper table:not([class*=vf-]) {
+  background-color: #ffffff;
+  border-collapse: collapse;
+}
+.vf-content table:not([class*=vf-]) caption, .editor-styles-wrapper table:not([class*=vf-]) caption {
+  font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
+  font-size: 21px;
+  font-weight: 500;
+  line-height: 1.29;
+  margin: 0 0 16px 0;
+  margin: 0 0 var(--vf-text-margin--bottom, 16px) 0;
+  text-align: left;
+}
+.vf-content table:not([class*=vf-]) thead, .editor-styles-wrapper table:not([class*=vf-]) thead {
+  background-color: #d0d0ce;
+}
+.vf-content table:not([class*=vf-]) thead th, .editor-styles-wrapper table:not([class*=vf-]) thead th {
+  font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
+  font-size: 19px;
+  font-weight: 500;
+  line-height: 1.5;
+  margin: 0 0 0 0;
+  padding: 8px 16px;
+  text-align: left;
+}
+.vf-content table:not([class*=vf-]) td, .editor-styles-wrapper table:not([class*=vf-]) td {
+  font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
+  font-size: 19px;
+  font-weight: 400;
+  line-height: 1.421;
+  margin: 0 0 0 0;
+  padding: 8px 16px;
+  text-align: left;
+  vertical-align: top;
+}
+.vf-content table:not([class*=vf-]) tr:nth-of-type(even), .editor-styles-wrapper table:not([class*=vf-]) tr:nth-of-type(even) {
+  background-color: #f3f3f3;
+}
+.vf-content table:not([class*=vf-]) tfoot, .editor-styles-wrapper table:not([class*=vf-]) tfoot {
+  background-color: #d0d0ce;
+  border-top: 1px solid #000000;
+}
+.vf-content table:not([class*=vf-]) tfoot td, .editor-styles-wrapper table:not([class*=vf-]) tfoot td {
+  padding: 8px 16px;
+}
+.vf-content figcaption:not([class*=vf-]), .editor-styles-wrapper figcaption:not([class*=vf-]),
+.vf-content cite:not([class*=vf-]),
+.editor-styles-wrapper cite:not([class*=vf-]) {
+  font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 1.57;
+  margin: 0 0 16px 0;
+  margin: 0 0 var(--vf-text-margin--bottom, 16px) 0;
+  color: #707372;
+  font-style: italic;
+}
+.vf-content .vf-video, .editor-styles-wrapper .vf-video {
+  margin-bottom: 32px;
+}
+.vf-content .vf-figure--align-inline-start, .editor-styles-wrapper .vf-figure--align-inline-start {
+  margin-bottom: 32px;
+  margin-right: 32px;
+}
+.vf-content .vf-figure--align-inline-end, .editor-styles-wrapper .vf-figure--align-inline-end {
+  margin-bottom: 32px;
+  margin-left: 32px;
+}
+
+.vf-content__standfirst {
+  font-size: 21px;
+  line-height: 31px;
+  margin-bottom: 46px;
+  margin-top: 0;
+}
+.vf-content__standfirst + .vf-content__standfirst {
+  margin-bottom: 24px;
+}
+.vf-content__standfirst + small {
+  margin-bottom: 42px;
+}
+
+[class*="--dark"].vf-content .vf-link, [class*="--dark"].editor-styles-wrapper .vf-link,
+[class*="--dark"].vf-content a:not([class*=vf-]),
+[class*="--dark"].editor-styles-wrapper a:not([class*=vf-]),
+.vf-content > [class*=dark] .vf-link,
+.editor-styles-wrapper > [class*=dark] .vf-link,
+.vf-content > [class*=dark] a:not([class*=vf-]),
+.editor-styles-wrapper > [class*=dark] a:not([class*=vf-]) {
+  border-bottom: none;
+  text-decoration: none;
+  color: #a8d2ff;
+}
+[class*="--dark"].vf-content .vf-link:visited, [class*="--dark"].editor-styles-wrapper .vf-link:visited,
+[class*="--dark"].vf-content a:not([class*=vf-]):visited,
+[class*="--dark"].editor-styles-wrapper a:not([class*=vf-]):visited,
+.vf-content > [class*=dark] .vf-link:visited,
+.editor-styles-wrapper > [class*=dark] .vf-link:visited,
+.vf-content > [class*=dark] a:not([class*=vf-]):visited,
+.editor-styles-wrapper > [class*=dark] a:not([class*=vf-]):visited {
+  color: #cba3d8;
+  border-bottom: none;
+}
+[class*="--dark"].vf-content .vf-link:visited:hover, [class*="--dark"].editor-styles-wrapper .vf-link:visited:hover,
+[class*="--dark"].vf-content a:not([class*=vf-]):visited:hover,
+[class*="--dark"].editor-styles-wrapper a:not([class*=vf-]):visited:hover,
+.vf-content > [class*=dark] .vf-link:visited:hover,
+.editor-styles-wrapper > [class*=dark] .vf-link:visited:hover,
+.vf-content > [class*=dark] a:not([class*=vf-]):visited:hover,
+.editor-styles-wrapper > [class*=dark] a:not([class*=vf-]):visited:hover {
+  color: #cba3d8;
+  text-decoration: underline;
+}
+[class*="--dark"].vf-content .vf-link:hover, [class*="--dark"].editor-styles-wrapper .vf-link:hover,
+[class*="--dark"].vf-content a:not([class*=vf-]):hover,
+[class*="--dark"].editor-styles-wrapper a:not([class*=vf-]):hover,
+.vf-content > [class*=dark] .vf-link:hover,
+.editor-styles-wrapper > [class*=dark] .vf-link:hover,
+.vf-content > [class*=dark] a:not([class*=vf-]):hover,
+.editor-styles-wrapper > [class*=dark] a:not([class*=vf-]):hover {
+  color: #a8d2ff;
+  border-bottom: none;
+  text-decoration: underline;
 }
 
 /*!
@@ -172,6 +387,12 @@
 .wp-list-table .column-vf_hash,
 .wp-list-table .column-vf_modified {
   width: 10%;
+}
+
+.wp-block {
+  max-width: 780px;
+  margin-left: auto !important;
+  margin-right: auto !important;
 }
 
 .post-type-vf_block .edit-post-visual-editor,
@@ -200,10 +421,6 @@
       -ms-flex-positive: 0;
           flex-grow: 0;
 }
-.post-type-vf_block .edit-post-layout__metaboxes .acf-hndle-cog,
-.post-type-vf_container .edit-post-layout__metaboxes .acf-hndle-cog {
-  display: none !important;
-}
 
 .editor-post-title__block {
   --vf-text-margin--bottom: 0;
@@ -217,63 +434,11 @@
   margin: 0 0 var(--vf-text-margin--bottom, 16px) 0;
 }
 
-.editor-styles-wrapper h1 {
-  font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
-  font-size: 42px;
-  font-weight: 700;
-  line-height: 1.547;
-  margin: 0 0 16px 0;
-  margin: 0 0 var(--vf-text-margin--bottom, 16px) 0;
+.editor-styles-wrapper .vf-details[open] .vf-details--summary {
+  pointer-events: none;
 }
-.editor-styles-wrapper h2 {
-  font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
-  font-size: 30px;
-  font-weight: 500;
-  line-height: 1.333;
-  margin: 0 0 16px 0;
-  margin: 0 0 var(--vf-text-margin--bottom, 16px) 0;
-}
-.editor-styles-wrapper h3 {
-  font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
-  font-size: 24px;
-  font-weight: 500;
-  line-height: 1.333;
-  margin: 0 0 16px 0;
-  margin: 0 0 var(--vf-text-margin--bottom, 16px) 0;
-}
-.editor-styles-wrapper h4 {
-  font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
-  font-size: 21px;
-  font-weight: 500;
-  line-height: 1.29;
-  margin: 0 0 16px 0;
-  margin: 0 0 var(--vf-text-margin--bottom, 16px) 0;
-}
-.editor-styles-wrapper h5 {
-  font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
-  font-size: 19px;
-  font-weight: 500;
-  line-height: 1.5;
-  margin: 0 0 16px 0;
-  margin: 0 0 var(--vf-text-margin--bottom, 16px) 0;
-}
-.editor-styles-wrapper h6 {
-  font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
-  font-size: 19px;
-  font-weight: 500;
-  line-height: 1.5;
-  margin: 0 0 16px 0;
-  margin: 0 0 var(--vf-text-margin--bottom, 16px) 0;
-}
-.editor-styles-wrapper p {
-  font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
-  font-size: 19px;
-  font-weight: 400;
-  line-height: 1.421;
-  margin: 0 0 16px 0;
-  margin: 0 0 var(--vf-text-margin--bottom, 16px) 0;
-}
-.editor-styles-wrapper .has-extra-large-font-size {
+
+.block-editor .editor-styles-wrapper .has-extra-large-font-size {
   font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
   font-size: 32px;
   font-weight: 500;
@@ -281,7 +446,7 @@
   margin: 0 0 16px 0;
   margin: 0 0 var(--vf-text-margin--bottom, 16px) 0;
 }
-.editor-styles-wrapper .has-large-font-size {
+.block-editor .editor-styles-wrapper .has-large-font-size {
   font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
   font-size: 19px;
   font-weight: 400;
@@ -289,7 +454,7 @@
   margin: 0 0 16px 0;
   margin: 0 0 var(--vf-text-margin--bottom, 16px) 0;
 }
-.editor-styles-wrapper .has-regular-font-size {
+.block-editor .editor-styles-wrapper .has-regular-font-size {
   font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
   font-size: 16px;
   font-weight: 400;
@@ -297,7 +462,7 @@
   margin: 0 0 16px 0;
   margin: 0 0 var(--vf-text-margin--bottom, 16px) 0;
 }
-.editor-styles-wrapper .has-small-font-size {
+.block-editor .editor-styles-wrapper .has-small-font-size {
   font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
   font-size: 14px;
   font-weight: 500;
@@ -305,99 +470,11 @@
   margin: 0 0 16px 0;
   margin: 0 0 var(--vf-text-margin--bottom, 16px) 0;
 }
-.editor-styles-wrapper .has-extra-small-font-size {
+.block-editor .editor-styles-wrapper .has-extra-small-font-size {
   font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
   font-size: 14px;
   font-weight: 400;
   line-height: 1.57;
   margin: 0 0 16px 0;
   margin: 0 0 var(--vf-text-margin--bottom, 16px) 0;
-}
-
-.wp-block {
-  max-width: 780px;
-}
-.wp-block .block-editor-default-block-appender {
-  --vf-text-margin--bottom: 0;
-}
-.wp-block .block-editor-default-block-appender .block-editor-default-block-appender__content {
-  font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
-  font-size: 19px;
-  font-weight: 400;
-  line-height: 1.421;
-  margin: 0 0 16px 0;
-  margin: 0 0 var(--vf-text-margin--bottom, 16px) 0;
-}
-
-.wp-block[data-type="core/heading"] {
-  --vf-text-margin--bottom: 0;
-}
-
-.wp-block[data-type="core/paragraph"] {
-  --vf-text-margin--bottom: 0;
-}
-
-.wp-block[data-type="core/list"] {
-  --vf-text-margin--bottom: 0;
-}
-.wp-block[data-type="core/list"] .editor-rich-text li {
-  font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
-  font-size: 19px;
-  font-weight: 400;
-  line-height: 1.421;
-  margin: 0 0 16px 0;
-  margin: 0 0 var(--vf-text-margin--bottom, 16px) 0;
-  margin-bottom: 8px;
-}
-
-.wp-block[data-type="core/quote"] {
-  --vf-text-margin--bottom: 16px;
-}
-.wp-block[data-type="core/quote"] .editor-rich-text p {
-  font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
-  font-size: 19px;
-  font-weight: 400;
-  line-height: 1.421;
-  margin: 0 0 16px 0;
-  margin: 0 0 var(--vf-text-margin--bottom, 16px) 0;
-}
-.wp-block[data-type="core/quote"] .wp-block-quote__citation {
-  font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
-  font-size: 14px;
-  font-weight: 500;
-  line-height: 1.57;
-  margin: 0 0 16px 0;
-  margin: 0 0 var(--vf-text-margin--bottom, 16px) 0;
-}
-.wp-block[data-type="core/quote"] .wp-block-quote {
-  border-left: 4px solid #d0d0ce;
-}
-
-.wp-block[data-type="core/table"] {
-  --vf-text-margin--bottom: 0;
-}
-.wp-block[data-type="core/table"] .editor-rich-text {
-  font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
-  font-size: 16px;
-  font-weight: 400;
-  line-height: 1.71;
-  margin: 0 0 16px 0;
-  margin: 0 0 var(--vf-text-margin--bottom, 16px) 0;
-}
-
-.wp-block[data-type="core/archives"],
-.wp-block[data-type="core/categories"],
-.wp-block[data-type="core/latest-posts"] {
-  --vf-text-margin--bottom: 0;
-}
-.wp-block[data-type="core/archives"] li,
-.wp-block[data-type="core/categories"] li,
-.wp-block[data-type="core/latest-posts"] li {
-  font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
-  font-size: 19px;
-  font-weight: 400;
-  line-height: 1.421;
-  margin: 0 0 16px 0;
-  margin: 0 0 var(--vf-text-margin--bottom, 16px) 0;
-  margin-bottom: 8px;
 }

--- a/vf-components/vfwp-admin/vfwp-admin.css
+++ b/vf-components/vfwp-admin/vfwp-admin.css
@@ -54,7 +54,7 @@
 /*!
  * Component: @visual-framework/vf-font-plex-sans
  * Version: 1.1.0
- * Location: components/vf-font-plex-sans
+ * Location: components/vf-core-
  */
 @font-face {
   font-family: "IBM Plex Sans";

--- a/vf-components/vfwp-admin/vfwp-admin.scss
+++ b/vf-components/vfwp-admin/vfwp-admin.scss
@@ -1,10 +1,12 @@
 // vfwp-admin
 
-@import 'vf-font-plex-sans/vf-font-plex-sans.scss';
+// @import "vf-font-plex-sans/vf-font-plex-sans.scss";
 
-@import 'vfwp-admin.variables.scss';
+@import "vf-content/vf-content.scss";
 
-@import 'package.variables.scss';
+@import "vfwp-admin.variables.scss";
+
+@import "package.variables.scss";
 
 // Debug information from component's `package.json`:
 // ---
@@ -25,6 +27,13 @@
   .column-vf_modified {
     width: 10%;
   }
+}
+
+// Placeholder block
+.wp-block {
+  max-width: 780px;
+  margin-left: auto !important;
+  margin-right: auto !important;
 }
 
 .post-type-vf_block,
@@ -48,11 +57,6 @@
     &:empty {
       flex-grow: 0;
     }
-
-    // Hide ACF field settings
-    .acf-hndle-cog {
-      display: none !important;
-    }
   }
 }
 
@@ -65,119 +69,39 @@
   }
 }
 
+// Extend basic typography styles within editor
 .editor-styles-wrapper {
-  h1 {
-    @include set-type(text-heading--1);
-  }
-  h2 {
-    @include set-type(text-heading--2);
-  }
-  h3 {
-    @include set-type(text-heading--3);
-  }
-  h4 {
-    @include set-type(text-heading--4);
-  }
-  h5 {
-    @include set-type(text-heading--5);
-  }
-  h6 {
-    @include set-type(text-heading--5);
-  }
+  @extend .vf-content;
 
-  p {
-    @include set-type(text-body--2);
-    // override WordPress defaults :(
-    // line-height: 1.421 !important;
-  }
-
-  .has-extra-large-font-size {
-    @include set-type(text-body--1);
-  }
-
-  .has-large-font-size {
-    @include set-type(text-body--2);
-  }
-
-  .has-regular-font-size {
-    @include set-type(text-body--3);
-  }
-
-  .has-small-font-size {
-    @include set-type(text-body--4);
-  }
-
-  .has-extra-small-font-size {
-    @include set-type(text-body--5);
-  }
-}
-
-// Placeholder block
-.wp-block {
-  max-width: 780px;
-
-  .block-editor-default-block-appender {
-    --vf-text-margin--bottom: 0;
-
-    .block-editor-default-block-appender__content {
-      @include set-type(text-body--2);
+  // Stop user from collapsing the dialog summary
+  .vf-details[open] {
+    .vf-details--summary {
+      pointer-events: none;
     }
   }
 }
 
-.wp-block[data-type='core/heading'] {
-  --vf-text-margin--bottom: 0;
-}
-
-.wp-block[data-type='core/paragraph'] {
-  --vf-text-margin--bottom: 0;
-}
-
-.wp-block[data-type='core/list'] {
-  --vf-text-margin--bottom: 0;
-
-  .editor-rich-text {
-    li {
-      @include set-type(text-body--2);
-      margin-bottom: map-get($vf-spacing-map, vf-spacing--sm);
+// Include custom typography styles within editor
+.block-editor {
+  .editor-styles-wrapper {
+    .has-extra-large-font-size {
+      @include set-type(text-body--1);
     }
-  }
-}
 
-.wp-block[data-type='core/quote'] {
-  --vf-text-margin--bottom: 16px;
-
-  .editor-rich-text {
-    p {
+    .has-large-font-size {
       @include set-type(text-body--2);
     }
-  }
 
-  .wp-block-quote__citation {
-    @include set-type(text-body--4);
-  }
+    .has-regular-font-size {
+      @include set-type(text-body--3);
+    }
 
-  .wp-block-quote {
-    border-left: 4px solid #d0d0ce;
-  }
-}
+    .has-small-font-size {
+      @include set-type(text-body--4);
+    }
 
-.wp-block[data-type='core/table'] {
-  --vf-text-margin--bottom: 0;
-
-  .editor-rich-text {
-    @include set-type(text-body--3);
-  }
-}
-
-// Widget blocks
-.wp-block[data-type='core/archives'],
-.wp-block[data-type='core/categories'],
-.wp-block[data-type='core/latest-posts'] {
-  --vf-text-margin--bottom: 0;
-
-  li {
-    @include set-type(text-body--2);
-    margin-bottom: map-get($vf-spacing-map, vf-spacing--sm);
+    .has-extra-small-font-size {
+      @include set-type(text-body--5);
+    }
   }
 }

--- a/wp-content/plugins/vf-gutenberg/vf-gutenberg.php
+++ b/wp-content/plugins/vf-gutenberg/vf-gutenberg.php
@@ -305,7 +305,9 @@ class VF_Gutenberg {
       */ ?>
   </div>
   <?php if ($is_jsx) { ?>
-  <InnerBlocks />
+  <div class="vf-block__inner-blocks">
+    <InnerBlocks />
+  </div>
   <?php } ?>
 </div>
 <script>

--- a/wp-content/plugins/vf-gutenberg/vf-gutenberg.php
+++ b/wp-content/plugins/vf-gutenberg/vf-gutenberg.php
@@ -244,6 +244,7 @@ class VF_Gutenberg {
   static function acf_render_template($args, $template, $acf_id = false) {
     $block = $args[0];
     $is_preview = $args[2];
+    $is_jsx = isset($block['supports']['jsx']) && $block['supports']['jsx'];
     if ( ! $acf_id) {
       $acf_id = $block['id'];
     }
@@ -293,7 +294,23 @@ class VF_Gutenberg {
     }
     $id = "vfwp_{$block['id']}";
 ?>
+<div class="vf-block" data-acf-id="<?php echo esc_attr($acf_id); ?>" data-editing="false" data-loading="false">
+  <div class="vf-block__view">
+    <?php /*
+    <iframe
+      class="vf-block__iframe"
+      id="<?php echo $id; ?>"
+      onLoad="<?php echo "setTimeout(()=>{{$id}();}, 1);"; ?>"
+      scrolling="no"></iframe>
+      */ ?>
+  </div>
+  <?php if ($is_jsx) { ?>
+  <InnerBlocks />
+  <?php } ?>
+</div>
 <script>
+(function() {
+
 window.<?php echo $id; ?> = function() {
   const iframe = document.getElementById('<?php echo $id; ?>');
   iframe.vfActive = true;
@@ -329,16 +346,27 @@ if (ResizeObserver) {
   doc.body.appendChild(script);
   doc.body.classList.add('ebi-vf1-integration');
 };
+
+const parent = document.querySelector('[data-acf-id="<?php echo esc_attr($acf_id); ?>"]');
+let iframe = document.getElementById('<?php echo $id; ?>');
+const onLoad = () => {
+  if (typeof window[iframe.id] === 'function') {
+    window[iframe.id]();
+  }
+};
+if (iframe) {
+  onLoad();
+} else {
+  iframe = document.createElement('iframe');
+  iframe.id = '<?php echo $id; ?>';
+  iframe.className = 'vf-block__iframe';
+  iframe.setAttribute('scrolling', 'no');
+  iframe.onload = onLoad;
+  parent.insertBefore(iframe, parent.firstChild);
+}
+
+})();
 </script>
-<div class="vf-block" data-acf-id="<?php echo esc_attr($acf_id); ?>" data-editing="false" data-loading="false">
-  <div class="vf-block__view">
-    <iframe
-      class="vf-block__iframe"
-      id="<?php echo $id; ?>"
-      onload="<?php echo "setTimeout(()=>{{$id}();}, 1);"; ?>"
-      scrolling="no"></iframe>
-  </div>
-</div>
 <?php
   // Toggle the Gutenberg editor block style for containers
   $is_container = get_field('is_container', $acf_id);

--- a/wp-content/themes/vf-wp/assets/assets/ebi-vf1-integration/ebi-vf1-integration.css
+++ b/wp-content/themes/vf-wp/assets/assets/ebi-vf1-integration/ebi-vf1-integration.css
@@ -60,7 +60,7 @@
 /*!
  * Component: @visual-framework/ebi-vf1-integration
  * Version: 1.0.4
- * Location: components/ebi-vf1-integration
+ * Location: components/vf-core-
  */
 .ebi-vf1-integration,
 html body.ebi-vf1-integration {
@@ -172,7 +172,7 @@ body.ebi-vf1-integration,
 /*!
  * Component: @visual-framework/vf-font-plex-sans
  * Version: 1.1.0
- * Location: components/vf-font-plex-sans
+ * Location: components/vf-core-
  */
 @font-face {
   font-family: "IBM Plex Sans";
@@ -281,7 +281,7 @@ body.ebi-vf1-integration,
 /*!
  * Component: @visual-framework/vf-font-plex-mono
  * Version: 1.1.0
- * Location: components/vf-font-plex-mono
+ * Location: components/vf-core-
  */
 @font-face {
   font-family: "IBM Plex Mono";

--- a/wp-content/themes/vf-wp/assets/assets/embl-breadcrumbs-lookup/embl-breadcrumbs-lookup.css
+++ b/wp-content/themes/vf-wp/assets/assets/embl-breadcrumbs-lookup/embl-breadcrumbs-lookup.css
@@ -54,7 +54,7 @@
 /*!
  * Component: @visual-framework/embl-breadcrumbs-lookup
  * Version: 1.0.0
- * Location: components/embl-breadcrumbs-lookup
+ * Location: components/vf-core-
  */
 .embl-grid .embl-breadcrumbs-lookup:first-child {
   grid-column: 1/-1;

--- a/wp-content/themes/vf-wp/assets/assets/embl-conditional-edit/embl-conditional-edit.css
+++ b/wp-content/themes/vf-wp/assets/assets/embl-conditional-edit/embl-conditional-edit.css
@@ -54,7 +54,7 @@
 /*!
  * Component: @visual-framework/embl-conditional-edit
  * Version: 1.0.2
- * Location: components/embl-conditional-edit
+ * Location: components/vf-core-
  */
 .embl-conditional-edit {
   display: none;

--- a/wp-content/themes/vf-wp/assets/assets/embl-content-hub-loader/embl-content-hub-loader.css
+++ b/wp-content/themes/vf-wp/assets/assets/embl-content-hub-loader/embl-content-hub-loader.css
@@ -54,7 +54,7 @@
 /*!
  * Component: @visual-framework/embl-content-hub-loader
  * Version: 1.0.6
- * Location: components/embl-content-hub-loader
+ * Location: components/vf-core-
  */
 .embl-grid > .vf-content-hub-html,
 .embl-grid > .embl-content-hub-html,

--- a/wp-content/themes/vf-wp/assets/assets/embl-content-meta-properties/embl-content-meta-properties.css
+++ b/wp-content/themes/vf-wp/assets/assets/embl-content-meta-properties/embl-content-meta-properties.css
@@ -54,5 +54,5 @@
 /*!
  * Component: @visual-framework/embl-content-meta-properties
  * Version: 1.0.1
- * Location: components/embl-content-meta-properties
+ * Location: components/vf-core-
  */

--- a/wp-content/themes/vf-wp/assets/assets/embl-grid/embl-grid.css
+++ b/wp-content/themes/vf-wp/assets/assets/embl-grid/embl-grid.css
@@ -54,7 +54,7 @@
 /*!
 * Component: @visual-framework/embl-grid
 * Version: 2.0.4
-* Location: components/embl-grid
+* Location: components/vf-core-
 */
 .embl-grid {
   margin-bottom: 48px;

--- a/wp-content/themes/vf-wp/assets/assets/embl-logo/embl-logo.css
+++ b/wp-content/themes/vf-wp/assets/assets/embl-logo/embl-logo.css
@@ -54,7 +54,7 @@
 /*!
  * Component: @visual-framework/embl-logo
  * Version: 1.0.4
- * Location: components/embl-logo
+ * Location: components/vf-core-
  */
 .embl-logo {
   background-image: url("../assets/embl-logo/assets/logo-medium.svg");

--- a/wp-content/themes/vf-wp/assets/assets/embl-notifications/embl-notifications.css
+++ b/wp-content/themes/vf-wp/assets/assets/embl-notifications/embl-notifications.css
@@ -54,5 +54,5 @@
 /*!
  * Component: @visual-framework/embl-notifications
  * Version: 1.0.0-beta.0
- * Location: components/embl-notifications
+ * Location: components/vf-core-
  */

--- a/wp-content/themes/vf-wp/assets/assets/vf-activity-list/vf-activity-list.css
+++ b/wp-content/themes/vf-wp/assets/assets/vf-activity-list/vf-activity-list.css
@@ -53,8 +53,8 @@
 /* stylelint-enable */
 /*!
  * Component: @visual-framework/vf-list
- * Version: 1.0.0-rc.1
- * Location: components/vf-list
+ * Version: 1.0.0
+ * Location: components/vf-core-
  */
 .vf-list {
   list-style-type: none;
@@ -132,7 +132,7 @@
 /*!
  * Component: @visual-framework/vf-blockquote
  * Version: 1.0.2
- * Location: components/vf-blockquote
+ * Location: components/vf-core-
  */
 .vf-blockquote {
   font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
@@ -166,8 +166,8 @@
 
 /*!
  * Component: @visual-framework/vf-activity-list
- * Version: 1.0.0-alpha.8
- * Location: components/vf-activity-list
+ * Version: 1.0.0-alpha.9
+ * Location: components/vf-core-
  */
 .vf-activity {
   margin-bottom: 54px;

--- a/wp-content/themes/vf-wp/assets/assets/vf-analytics-google/vf-analytics-google.css
+++ b/wp-content/themes/vf-wp/assets/assets/vf-analytics-google/vf-analytics-google.css
@@ -54,5 +54,5 @@
 /*!
  * Component: @visual-framework/vf-analytics-google
  * Version: 1.0.0-rc.1
- * Location: components/vf-analytics-google
+ * Location: components/vf-core-
  */

--- a/wp-content/themes/vf-wp/assets/assets/vf-article-meta-information/vf-article-meta-information.css
+++ b/wp-content/themes/vf-wp/assets/assets/vf-article-meta-information/vf-article-meta-information.css
@@ -54,7 +54,7 @@
 /*!
  * Component: @visual-framework/vf-article-meta-information
  * Version: 1.1.0
- * Location: components/vf-article-meta-information
+ * Location: components/vf-core-
  */
 .vf-article-meta-information {
   display: grid;

--- a/wp-content/themes/vf-wp/assets/assets/vf-badge/vf-badge.css
+++ b/wp-content/themes/vf-wp/assets/assets/vf-badge/vf-badge.css
@@ -54,7 +54,7 @@
 /*!
  * Component: @visual-framework/vf-badge
  * Version: 1.2.1
- * Location: components/vf-badge
+ * Location: components/vf-core-
  */
 .vf-badge {
   font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;

--- a/wp-content/themes/vf-wp/assets/assets/vf-banner/vf-banner.css
+++ b/wp-content/themes/vf-wp/assets/assets/vf-banner/vf-banner.css
@@ -54,7 +54,7 @@
 /*!
  * Component: @visual-framework/vf-banner
  * Version: 1.4.0
- * Location: components/vf-banner
+ * Location: components/vf-core-
  */
 .vf-banner {
   -webkit-box-sizing: border-box;

--- a/wp-content/themes/vf-wp/assets/assets/vf-blockquote/vf-blockquote.css
+++ b/wp-content/themes/vf-wp/assets/assets/vf-blockquote/vf-blockquote.css
@@ -54,7 +54,7 @@
 /*!
  * Component: @visual-framework/vf-blockquote
  * Version: 1.0.2
- * Location: components/vf-blockquote
+ * Location: components/vf-core-
  */
 .vf-blockquote {
   font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;

--- a/wp-content/themes/vf-wp/assets/assets/vf-box/vf-box.css
+++ b/wp-content/themes/vf-wp/assets/assets/vf-box/vf-box.css
@@ -54,7 +54,7 @@
 /*!
  * Component: @visual-framework/vf-box
  * Version: 2.0.2
- * Location: components/vf-box
+ * Location: components/vf-core-
  */
 .vf-box {
   --box-text-color: var( --vf-box-theme-color--foreground, var(--vf-theme-color--foreground, #000000));

--- a/wp-content/themes/vf-wp/assets/assets/vf-breadcrumbs/vf-breadcrumbs.css
+++ b/wp-content/themes/vf-wp/assets/assets/vf-breadcrumbs/vf-breadcrumbs.css
@@ -53,8 +53,8 @@
 /* stylelint-enable */
 /*!
  * Component: @visual-framework/vf-list
- * Version: 1.0.0-rc.1
- * Location: components/vf-list
+ * Version: 1.0.0
+ * Location: components/vf-core-
  */
 .vf-list {
   list-style-type: none;
@@ -132,7 +132,7 @@
 /*!
  * Component: @visual-framework/vf-breadcrumbs
  * Version: 1.0.4
- * Location: components/vf-breadcrumbs
+ * Location: components/vf-core-
  */
 .vf-breadcrumbs {
   grid-column: main;

--- a/wp-content/themes/vf-wp/assets/assets/vf-button/vf-button.css
+++ b/wp-content/themes/vf-wp/assets/assets/vf-button/vf-button.css
@@ -54,7 +54,7 @@
 /*!
 * Component: @visual-framework/vf-button
 * Version: 1.1.1
-* Location: components/vf-button
+* Location: components/vf-core-
 */
 .vf-button {
   --vf-button__color__background--default: var(--vf-color--grey);

--- a/wp-content/themes/vf-wp/assets/assets/vf-card-container/vf-card-container.css
+++ b/wp-content/themes/vf-wp/assets/assets/vf-card-container/vf-card-container.css
@@ -54,7 +54,7 @@
 /*!
  * Component: @visual-framework/vf-card-container
  * Version: 1.0.0
- * Location: components/vf-card-container
+ * Location: components/vf-core-
  */
 .vf-card-container {
   grid-column: 1/-1;

--- a/wp-content/themes/vf-wp/assets/assets/vf-card/vf-card.css
+++ b/wp-content/themes/vf-wp/assets/assets/vf-card/vf-card.css
@@ -54,7 +54,7 @@
 /*!
  * Component: @visual-framework/vf-card
  * Version: 2.1.2
- * Location: components/vf-card
+ * Location: components/vf-core-
  */
 .vf-card {
   --card-text-color: var(--vf-card-theme-color--foreground, #000000);

--- a/wp-content/themes/vf-wp/assets/assets/vf-code-example/vf-code-example.css
+++ b/wp-content/themes/vf-wp/assets/assets/vf-code-example/vf-code-example.css
@@ -54,7 +54,7 @@
 /*!
  * Component: @visual-framework/vf-code-example
  * Version: 1.0.1
- * Location: components/vf-code-example
+ * Location: components/vf-core-
  */
 .vf-content pre,
 .vf-content code,

--- a/wp-content/themes/vf-wp/assets/assets/vf-content/vf-content.css
+++ b/wp-content/themes/vf-wp/assets/assets/vf-content/vf-content.css
@@ -53,8 +53,8 @@
 /* stylelint-enable */
 /*!
  * Component: @visual-framework/vf-heading
- * Version: 1.0.0-rc.1
- * Location: components/vf-heading
+ * Version: 1.0.0
+ * Location: components/vf-core-
  */
 .vf-text {
   margin: 0 0 16px 0;
@@ -127,7 +127,7 @@
 /*!
  * Component: @visual-framework/vf-badge
  * Version: 1.2.1
- * Location: components/vf-badge
+ * Location: components/vf-core-
  */
 .vf-badge {
   font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
@@ -270,7 +270,7 @@ a.vf-badge--outline[class*=tertiary]:hover {
 /*!
  * Component: @visual-framework/vf-text
  * Version: 1.0.2
- * Location: components/vf-text
+ * Location: components/vf-core-
  */
 .vf-text-body a {
   border-bottom: none;
@@ -348,7 +348,7 @@ a.vf-badge--outline[class*=tertiary]:hover {
 /*!
  * Component: @visual-framework/vf-link
  * Version: 1.0.3
- * Location: components/vf-link
+ * Location: components/vf-core-
  */
 .vf-link {
   border-bottom: none;
@@ -405,12 +405,12 @@ a.vf-badge--outline[class*=tertiary]:hover {
 /*!
  * Component: @visual-framework/vf-form__core
  * Version: 1.0.3
- * Location: components/vf-form/vf-form__core
+ * Location: components/vf-core-
  */
 /*!
  * Component: @visual-framework/vf-form__helper
  * Version: 1.0.0
- * Location: components/vf-form/vf-form__helper
+ * Location: components/vf-core-
  */
 .vf-form__helper {
   font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
@@ -429,7 +429,7 @@ a.vf-badge--outline[class*=tertiary]:hover {
 /*!
  * Component: @visual-framework/vf-form__input
  * Version: 1.0.1
- * Location: components/vf-form/vf-form__input
+ * Location: components/vf-core-
  */
 .vf-form__input:not([type=file]) {
   font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
@@ -623,7 +623,7 @@ a.vf-badge--outline[class*=tertiary]:hover {
 /*!
  * Component: @visual-framework/vf-form__legend
  * Version: 1.0.1
- * Location: components/vf-form/vf-form__legend
+ * Location: components/vf-core-
  */
 .vf-form__legend {
   font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
@@ -636,7 +636,7 @@ a.vf-badge--outline[class*=tertiary]:hover {
 /*!
  * Component: @visual-framework/vf-form__fieldset
  * Version: 1.0.1
- * Location: components/vf-form/vf-form__fieldset
+ * Location: components/vf-core-
  */
 .vf-form__fieldset {
   border: 0;
@@ -647,7 +647,7 @@ a.vf-badge--outline[class*=tertiary]:hover {
 /*!
  * Component: @visual-framework/vf-form__select
  * Version: 1.0.0
- * Location: components/vf-form/vf-form__select
+ * Location: components/vf-core-
  */
 .vf-form__select {
   font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
@@ -694,7 +694,7 @@ a.vf-badge--outline[class*=tertiary]:hover {
 /*!
  * Component: @visual-framework/vf-form__checkbox
  * Version: 1.0.2
- * Location: components/vf-form/vf-form__checkbox
+ * Location: components/vf-core-
  */
 .vf-form__item.vf-form__item--checkbox {
   margin-bottom: 16px;
@@ -752,7 +752,7 @@ a.vf-badge--outline[class*=tertiary]:hover {
 /*!
  * Component: @visual-framework/vf-form__radio
  * Version: 1.0.1
- * Location: components/vf-form/vf-form__radio
+ * Location: components/vf-core-
  */
 .vf-form__radio {
   opacity: 0;
@@ -799,7 +799,7 @@ a.vf-badge--outline[class*=tertiary]:hover {
 /*!
  * Component: @visual-framework/vf-form__textarea
  * Version: 1.0.1
- * Location: components/vf-form/vf-form__textarea
+ * Location: components/vf-core-
  */
 .vf-form__textarea {
   font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
@@ -829,7 +829,7 @@ a.vf-badge--outline[class*=tertiary]:hover {
 /*!
  * Component: @visual-framework/vf-form__item
  * Version: 1.0.0
- * Location: components/vf-form/vf-form__item
+ * Location: components/vf-core-
  */
 .vf-form__item {
   margin-bottom: 32px;
@@ -842,7 +842,7 @@ a.vf-badge--outline[class*=tertiary]:hover {
 /*!
  * Component: @visual-framework/vf-form__label
  * Version: 1.0.1
- * Location: components/vf-form/vf-form__label
+ * Location: components/vf-core-
  */
 .vf-form__label {
   font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
@@ -866,7 +866,7 @@ a.vf-badge--outline[class*=tertiary]:hover {
 /*!
 * Component: @visual-framework/vf-button
 * Version: 1.1.1
-* Location: components/vf-button
+* Location: components/vf-core-
 */
 .vf-button {
   --vf-button__color__background--default: var(--vf-color--grey);
@@ -1057,7 +1057,7 @@ html:not(.vf-disable-deprecated) .vf-text-button--1 {
 /*!
  * Component: @visual-framework/vf-figure
  * Version: 1.3.0
- * Location: components/vf-figure
+ * Location: components/vf-core-
  */
 .vf-figure {
   margin: 0;
@@ -1108,8 +1108,8 @@ html:not(.vf-disable-deprecated) .vf-text-button--1 {
 
 /*!
  * Component: @visual-framework/vf-list
- * Version: 1.0.0-rc.1
- * Location: components/vf-list
+ * Version: 1.0.0
+ * Location: components/vf-core-
  */
 .vf-list {
   list-style-type: none;
@@ -1187,7 +1187,7 @@ html:not(.vf-disable-deprecated) .vf-text-button--1 {
 /*!
  * Component: @visual-framework/vf-blockquote
  * Version: 1.0.2
- * Location: components/vf-blockquote
+ * Location: components/vf-core-
  */
 .vf-blockquote {
   font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
@@ -1221,8 +1221,8 @@ html:not(.vf-disable-deprecated) .vf-text-button--1 {
 
 /*!
  * Component: @visual-framework/vf-divider
- * Version: 1.0.0-rc.8
- * Location: components/vf-divider
+ * Version: 1.0.0
+ * Location: components/vf-core-
  */
 .vf-divider {
   background-color: #d8d8d8;
@@ -1236,7 +1236,7 @@ html:not(.vf-disable-deprecated) .vf-text-button--1 {
 /*!
  * Component: @visual-framework/vf-box
  * Version: 2.0.2
- * Location: components/vf-box
+ * Location: components/vf-core-
  */
 .vf-box {
   --box-text-color: var( --vf-box-theme-color--foreground, var(--vf-theme-color--foreground, #000000));
@@ -1394,7 +1394,7 @@ html:not(.vf-disable-deprecated) .vf-text-button--1 {
 /*!
  * Component: @visual-framework/vf-content
  * Version: 1.2.2
- * Location: components/vf-content
+ * Location: components/vf-core-
  */
 .vf-content h1:not([class*=vf-]) {
   font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;

--- a/wp-content/themes/vf-wp/assets/assets/vf-details/vf-details.css
+++ b/wp-content/themes/vf-wp/assets/assets/vf-details/vf-details.css
@@ -54,7 +54,7 @@
 /*!
  * Component: @visual-framework/vf-details
  * Version: 1.0.0-alpha.1
- * Location: components/vf-details
+ * Location: components/vf-core-
  */
 .vf-details {
   padding: 8px 8px 0 8px;

--- a/wp-content/themes/vf-wp/assets/assets/vf-discussion/vf-discussion.css
+++ b/wp-content/themes/vf-wp/assets/assets/vf-discussion/vf-discussion.css
@@ -54,7 +54,7 @@
 /*!
  * Component: @visual-framework/vf-discussion
  * Version: 1.0.0
- * Location: components/vf-discussion
+ * Location: components/vf-core-
  */
 .vf-discussion__title {
   font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;

--- a/wp-content/themes/vf-wp/assets/assets/vf-divider/vf-divider.css
+++ b/wp-content/themes/vf-wp/assets/assets/vf-divider/vf-divider.css
@@ -53,8 +53,8 @@
 /* stylelint-enable */
 /*!
  * Component: @visual-framework/vf-divider
- * Version: 1.0.0-rc.8
- * Location: components/vf-divider
+ * Version: 1.0.0
+ * Location: components/vf-core-
  */
 .vf-divider {
   background-color: #d8d8d8;

--- a/wp-content/themes/vf-wp/assets/assets/vf-embed/vf-embed.css
+++ b/wp-content/themes/vf-wp/assets/assets/vf-embed/vf-embed.css
@@ -54,7 +54,7 @@
 /*!
  * Component: @visual-framework/vf-embed
  * Version: 1.1.0
- * Location: components/vf-embed
+ * Location: components/vf-core-
  */
 .vf-embed {
   max-width: var(--vf-embed-max-width, 100%);

--- a/wp-content/themes/vf-wp/assets/assets/vf-figure/vf-figure.css
+++ b/wp-content/themes/vf-wp/assets/assets/vf-figure/vf-figure.css
@@ -54,7 +54,7 @@
 /*!
  * Component: @visual-framework/vf-figure
  * Version: 1.3.0
- * Location: components/vf-figure
+ * Location: components/vf-core-
  */
 .vf-figure {
   margin: 0;

--- a/wp-content/themes/vf-wp/assets/assets/vf-footer/vf-footer.css
+++ b/wp-content/themes/vf-wp/assets/assets/vf-footer/vf-footer.css
@@ -54,7 +54,7 @@
 /*!
  * Component: @visual-framework/vf-footer
  * Version: 1.1.0
- * Location: components/vf-footer
+ * Location: components/vf-core-
  */
 .vf-footer {
   background-color: #54585a;

--- a/wp-content/themes/vf-wp/assets/assets/vf-form__checkbox/vf-form__checkbox.css
+++ b/wp-content/themes/vf-wp/assets/assets/vf-form__checkbox/vf-form__checkbox.css
@@ -54,7 +54,7 @@
 /*!
  * Component: @visual-framework/vf-form__item
  * Version: 1.0.0
- * Location: components/vf-form/vf-form__item
+ * Location: components/vf-core-
  */
 .vf-form__item {
   margin-bottom: 32px;
@@ -67,7 +67,7 @@
 /*!
  * Component: @visual-framework/vf-form__label
  * Version: 1.0.1
- * Location: components/vf-form/vf-form__label
+ * Location: components/vf-core-
  */
 .vf-form__label {
   font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
@@ -91,7 +91,7 @@
 /*!
  * Component: @visual-framework/vf-form__checkbox
  * Version: 1.0.2
- * Location: components/vf-form/vf-form__checkbox
+ * Location: components/vf-core-
  */
 .vf-form__item.vf-form__item--checkbox {
   margin-bottom: 16px;

--- a/wp-content/themes/vf-wp/assets/assets/vf-form__core/vf-form__core.css
+++ b/wp-content/themes/vf-wp/assets/assets/vf-form__core/vf-form__core.css
@@ -54,7 +54,7 @@
 /*!
  * Component: @visual-framework/vf-form__helper
  * Version: 1.0.0
- * Location: components/vf-form/vf-form__helper
+ * Location: components/vf-core-
  */
 .vf-form__helper {
   font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
@@ -73,7 +73,7 @@
 /*!
  * Component: @visual-framework/vf-form__input
  * Version: 1.0.1
- * Location: components/vf-form/vf-form__input
+ * Location: components/vf-core-
  */
 .vf-form__input:not([type=file]) {
   font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
@@ -267,7 +267,7 @@
 /*!
  * Component: @visual-framework/vf-form__legend
  * Version: 1.0.1
- * Location: components/vf-form/vf-form__legend
+ * Location: components/vf-core-
  */
 .vf-form__legend {
   font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
@@ -280,7 +280,7 @@
 /*!
  * Component: @visual-framework/vf-form__fieldset
  * Version: 1.0.1
- * Location: components/vf-form/vf-form__fieldset
+ * Location: components/vf-core-
  */
 .vf-form__fieldset {
   border: 0;
@@ -291,7 +291,7 @@
 /*!
  * Component: @visual-framework/vf-form__select
  * Version: 1.0.0
- * Location: components/vf-form/vf-form__select
+ * Location: components/vf-core-
  */
 .vf-form__select {
   font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
@@ -338,7 +338,7 @@
 /*!
  * Component: @visual-framework/vf-form__checkbox
  * Version: 1.0.2
- * Location: components/vf-form/vf-form__checkbox
+ * Location: components/vf-core-
  */
 .vf-form__item.vf-form__item--checkbox {
   margin-bottom: 16px;
@@ -396,7 +396,7 @@
 /*!
  * Component: @visual-framework/vf-form__radio
  * Version: 1.0.1
- * Location: components/vf-form/vf-form__radio
+ * Location: components/vf-core-
  */
 .vf-form__radio {
   opacity: 0;
@@ -443,7 +443,7 @@
 /*!
  * Component: @visual-framework/vf-form__textarea
  * Version: 1.0.1
- * Location: components/vf-form/vf-form__textarea
+ * Location: components/vf-core-
  */
 .vf-form__textarea {
   font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
@@ -473,7 +473,7 @@
 /*!
  * Component: @visual-framework/vf-form__item
  * Version: 1.0.0
- * Location: components/vf-form/vf-form__item
+ * Location: components/vf-core-
  */
 .vf-form__item {
   margin-bottom: 32px;
@@ -486,7 +486,7 @@
 /*!
  * Component: @visual-framework/vf-form__label
  * Version: 1.0.1
- * Location: components/vf-form/vf-form__label
+ * Location: components/vf-core-
  */
 .vf-form__label {
   font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;

--- a/wp-content/themes/vf-wp/assets/assets/vf-form__fieldset/vf-form__fieldset.css
+++ b/wp-content/themes/vf-wp/assets/assets/vf-form__fieldset/vf-form__fieldset.css
@@ -54,7 +54,7 @@
 /*!
  * Component: @visual-framework/vf-form__fieldset
  * Version: 1.0.1
- * Location: components/vf-form/vf-form__fieldset
+ * Location: components/vf-core-
  */
 .vf-form__fieldset {
   border: 0;

--- a/wp-content/themes/vf-wp/assets/assets/vf-form__helper/vf-form__helper.css
+++ b/wp-content/themes/vf-wp/assets/assets/vf-form__helper/vf-form__helper.css
@@ -54,7 +54,7 @@
 /*!
  * Component: @visual-framework/vf-form__helper
  * Version: 1.0.0
- * Location: components/vf-form/vf-form__helper
+ * Location: components/vf-core-
  */
 .vf-form__helper {
   font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;

--- a/wp-content/themes/vf-wp/assets/assets/vf-form__input/vf-form__input.css
+++ b/wp-content/themes/vf-wp/assets/assets/vf-form__input/vf-form__input.css
@@ -54,7 +54,7 @@
 /*!
  * Component: @visual-framework/vf-form__input
  * Version: 1.0.1
- * Location: components/vf-form/vf-form__input
+ * Location: components/vf-core-
  */
 .vf-form__input:not([type=file]) {
   font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;

--- a/wp-content/themes/vf-wp/assets/assets/vf-form__item/vf-form__item.css
+++ b/wp-content/themes/vf-wp/assets/assets/vf-form__item/vf-form__item.css
@@ -54,7 +54,7 @@
 /*!
  * Component: @visual-framework/vf-form__item
  * Version: 1.0.0
- * Location: components/vf-form/vf-form__item
+ * Location: components/vf-core-
  */
 .vf-form__item {
   margin-bottom: 32px;

--- a/wp-content/themes/vf-wp/assets/assets/vf-form__label/vf-form__label.css
+++ b/wp-content/themes/vf-wp/assets/assets/vf-form__label/vf-form__label.css
@@ -54,7 +54,7 @@
 /*!
  * Component: @visual-framework/vf-form__label
  * Version: 1.0.1
- * Location: components/vf-form/vf-form__label
+ * Location: components/vf-core-
  */
 .vf-form__label {
   font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;

--- a/wp-content/themes/vf-wp/assets/assets/vf-form__legend/vf-form__legend.css
+++ b/wp-content/themes/vf-wp/assets/assets/vf-form__legend/vf-form__legend.css
@@ -54,7 +54,7 @@
 /*!
  * Component: @visual-framework/vf-form__legend
  * Version: 1.0.1
- * Location: components/vf-form/vf-form__legend
+ * Location: components/vf-core-
  */
 .vf-form__legend {
   font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;

--- a/wp-content/themes/vf-wp/assets/assets/vf-form__radio/vf-form__radio.css
+++ b/wp-content/themes/vf-wp/assets/assets/vf-form__radio/vf-form__radio.css
@@ -54,7 +54,7 @@
 /*!
  * Component: @visual-framework/vf-form__radio
  * Version: 1.0.1
- * Location: components/vf-form/vf-form__radio
+ * Location: components/vf-core-
  */
 .vf-form__radio {
   opacity: 0;

--- a/wp-content/themes/vf-wp/assets/assets/vf-form__select/vf-form__select.css
+++ b/wp-content/themes/vf-wp/assets/assets/vf-form__select/vf-form__select.css
@@ -54,12 +54,12 @@
 /*!
  * Component: @visual-framework/vf-form__core
  * Version: 1.0.3
- * Location: components/vf-form/vf-form__core
+ * Location: components/vf-core-
  */
 /*!
  * Component: @visual-framework/vf-form__helper
  * Version: 1.0.0
- * Location: components/vf-form/vf-form__helper
+ * Location: components/vf-core-
  */
 .vf-form__helper {
   font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
@@ -78,7 +78,7 @@
 /*!
  * Component: @visual-framework/vf-form__input
  * Version: 1.0.1
- * Location: components/vf-form/vf-form__input
+ * Location: components/vf-core-
  */
 .vf-form__input:not([type=file]) {
   font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
@@ -272,7 +272,7 @@
 /*!
  * Component: @visual-framework/vf-form__legend
  * Version: 1.0.1
- * Location: components/vf-form/vf-form__legend
+ * Location: components/vf-core-
  */
 .vf-form__legend {
   font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
@@ -285,7 +285,7 @@
 /*!
  * Component: @visual-framework/vf-form__fieldset
  * Version: 1.0.1
- * Location: components/vf-form/vf-form__fieldset
+ * Location: components/vf-core-
  */
 .vf-form__fieldset {
   border: 0;
@@ -296,7 +296,7 @@
 /*!
  * Component: @visual-framework/vf-form__select
  * Version: 1.0.0
- * Location: components/vf-form/vf-form__select
+ * Location: components/vf-core-
  */
 .vf-form__select {
   font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
@@ -343,7 +343,7 @@
 /*!
  * Component: @visual-framework/vf-form__checkbox
  * Version: 1.0.2
- * Location: components/vf-form/vf-form__checkbox
+ * Location: components/vf-core-
  */
 .vf-form__item.vf-form__item--checkbox {
   margin-bottom: 16px;
@@ -401,7 +401,7 @@
 /*!
  * Component: @visual-framework/vf-form__radio
  * Version: 1.0.1
- * Location: components/vf-form/vf-form__radio
+ * Location: components/vf-core-
  */
 .vf-form__radio {
   opacity: 0;
@@ -448,7 +448,7 @@
 /*!
  * Component: @visual-framework/vf-form__textarea
  * Version: 1.0.1
- * Location: components/vf-form/vf-form__textarea
+ * Location: components/vf-core-
  */
 .vf-form__textarea {
   font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
@@ -478,7 +478,7 @@
 /*!
  * Component: @visual-framework/vf-form__item
  * Version: 1.0.0
- * Location: components/vf-form/vf-form__item
+ * Location: components/vf-core-
  */
 .vf-form__item {
   margin-bottom: 32px;
@@ -491,7 +491,7 @@
 /*!
  * Component: @visual-framework/vf-form__label
  * Version: 1.0.1
- * Location: components/vf-form/vf-form__label
+ * Location: components/vf-core-
  */
 .vf-form__label {
   font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
@@ -515,7 +515,7 @@
 /*!
  * Component: @visual-framework/vf-form__select
  * Version: 1.0.0
- * Location: components/vf-form/vf-form__select
+ * Location: components/vf-core-
  */
 .vf-form__select {
   font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;

--- a/wp-content/themes/vf-wp/assets/assets/vf-form__textarea/vf-form__textarea.css
+++ b/wp-content/themes/vf-wp/assets/assets/vf-form__textarea/vf-form__textarea.css
@@ -54,7 +54,7 @@
 /*!
  * Component: @visual-framework/vf-form__textarea
  * Version: 1.0.1
- * Location: components/vf-form/vf-form__textarea
+ * Location: components/vf-core-
  */
 .vf-form__textarea {
   font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;

--- a/wp-content/themes/vf-wp/assets/assets/vf-grid/vf-grid.css
+++ b/wp-content/themes/vf-wp/assets/assets/vf-grid/vf-grid.css
@@ -54,7 +54,7 @@
 /*!
  * Component: @visual-framework/vf-grid
  * Version: 1.2.0
- * Location: components/vf-grid
+ * Location: components/vf-core-
  */
 /* stylelint-disable order/order */
 .vf-grid {

--- a/wp-content/themes/vf-wp/assets/assets/vf-header/vf-header.css
+++ b/wp-content/themes/vf-wp/assets/assets/vf-header/vf-header.css
@@ -54,7 +54,7 @@
 /*!
  * Component: @visual-framework/vf-global-header
  * Version: 3.0.0
- * Location: components/vf-global-header
+ * Location: components/vf-core-
  */
 .vf-global-header {
   -webkit-box-align: center;
@@ -115,7 +115,7 @@ html:not(.vf-disable-deprecated) .vf-global-header__inner {
 /*!
  * Component: @visual-framework/vf-masthead
  * Version: 1.1.1
- * Location: components/vf-masthead
+ * Location: components/vf-core-
  */
 .vf-masthead {
   background-color: #ffffff;
@@ -334,7 +334,7 @@ html:not(.vf-disable-deprecated) .vf-global-header__inner {
 /*!
  * Component: @visual-framework/vf-navigation
  * Version: 1.2.5
- * Location: components/vf-navigation
+ * Location: components/vf-core-
  */
 .vf-navigation__list {
   display: -webkit-box;
@@ -353,7 +353,7 @@ html:not(.vf-disable-deprecated) .vf-global-header__inner {
 /*!
  * Component: @visual-framework/vf-header
  * Version: 1.0.2
- * Location: components/vf-header
+ * Location: components/vf-core-
  */
 .vf-header {
   background-position: top center;

--- a/wp-content/themes/vf-wp/assets/assets/vf-heading/vf-heading.css
+++ b/wp-content/themes/vf-wp/assets/assets/vf-heading/vf-heading.css
@@ -53,8 +53,8 @@
 /* stylelint-enable */
 /*!
  * Component: @visual-framework/vf-heading
- * Version: 1.0.0-rc.1
- * Location: components/vf-heading
+ * Version: 1.0.0
+ * Location: components/vf-core-
  */
 .vf-text {
   margin: 0 0 16px 0;

--- a/wp-content/themes/vf-wp/assets/assets/vf-hero/vf-hero.css
+++ b/wp-content/themes/vf-wp/assets/assets/vf-hero/vf-hero.css
@@ -54,7 +54,7 @@
 /*!
  * Component: @visual-framework/vf-hero
  * Version: 1.6.0
- * Location: components/vf-hero
+ * Location: components/vf-core-
  */
 /* stylelint-disable */
 .vf-hero {

--- a/wp-content/themes/vf-wp/assets/assets/vf-lede/vf-lede.css
+++ b/wp-content/themes/vf-wp/assets/assets/vf-lede/vf-lede.css
@@ -54,7 +54,7 @@
 /*!
  * Component: @visual-framework/vf-lede
  * Version: 1.0.1
- * Location: components/vf-lede
+ * Location: components/vf-core-
  */
 .vf-lede {
   font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;

--- a/wp-content/themes/vf-wp/assets/assets/vf-link/vf-link.css
+++ b/wp-content/themes/vf-wp/assets/assets/vf-link/vf-link.css
@@ -54,7 +54,7 @@
 /*!
  * Component: @visual-framework/vf-link
  * Version: 1.0.3
- * Location: components/vf-link
+ * Location: components/vf-core-
  */
 .vf-link {
   border-bottom: none;

--- a/wp-content/themes/vf-wp/assets/assets/vf-list/vf-list.css
+++ b/wp-content/themes/vf-wp/assets/assets/vf-list/vf-list.css
@@ -53,8 +53,8 @@
 /* stylelint-enable */
 /*!
  * Component: @visual-framework/vf-list
- * Version: 1.0.0-rc.1
- * Location: components/vf-list
+ * Version: 1.0.0
+ * Location: components/vf-core-
  */
 .vf-list {
   list-style-type: none;

--- a/wp-content/themes/vf-wp/assets/assets/vf-location-nearest/vf-location-nearest.css
+++ b/wp-content/themes/vf-wp/assets/assets/vf-location-nearest/vf-location-nearest.css
@@ -54,5 +54,5 @@
 /*!
  * Component: @visual-framework/vf-location-nearest
  * Version: 1.0.0-alpha.1
- * Location: components/vf-location-nearest
+ * Location: components/vf-core-
  */

--- a/wp-content/themes/vf-wp/assets/assets/vf-masthead/vf-masthead.css
+++ b/wp-content/themes/vf-wp/assets/assets/vf-masthead/vf-masthead.css
@@ -54,7 +54,7 @@
 /*!
  * Component: @visual-framework/vf-grid
  * Version: 1.2.0
- * Location: components/vf-grid
+ * Location: components/vf-core-
  */
 /* stylelint-disable order/order */
 .vf-grid {
@@ -237,7 +237,7 @@
 /*!
  * Component: @visual-framework/vf-masthead
  * Version: 1.1.1
- * Location: components/vf-masthead
+ * Location: components/vf-core-
  */
 .vf-masthead {
   background-color: #ffffff;

--- a/wp-content/themes/vf-wp/assets/assets/vf-navigation/vf-navigation.css
+++ b/wp-content/themes/vf-wp/assets/assets/vf-navigation/vf-navigation.css
@@ -53,8 +53,8 @@
 /* stylelint-enable */
 /*!
  * Component: @visual-framework/vf-list
- * Version: 1.0.0-rc.1
- * Location: components/vf-list
+ * Version: 1.0.0
+ * Location: components/vf-core-
  */
 .vf-list {
   list-style-type: none;
@@ -132,7 +132,7 @@
 /*!
  * Component: @visual-framework/vf-navigation
  * Version: 1.2.5
- * Location: components/vf-navigation
+ * Location: components/vf-core-
  */
 .vf-navigation__list {
   display: -webkit-box;

--- a/wp-content/themes/vf-wp/assets/assets/vf-news-container/vf-news-container.css
+++ b/wp-content/themes/vf-wp/assets/assets/vf-news-container/vf-news-container.css
@@ -54,7 +54,7 @@
 /*!
  * Component: @visual-framework/vf-grid
  * Version: 1.2.0
- * Location: components/vf-grid
+ * Location: components/vf-core-
  */
 /* stylelint-disable order/order */
 .vf-grid {
@@ -237,7 +237,7 @@
 /*!
  * Component: @visual-framework/vf-summary
  * Version: 1.3.1
- * Location: components/vf-summary
+ * Location: components/vf-core-
  */
 .vf-summary {
   --vf-text-margin--bottom: 16px;
@@ -531,7 +531,7 @@ html:not(.vf-disable-deprecated) .vf-summary--profile-s .vf-summary__title {
 /*!
  * Component: @visual-framework/vf-section-header
  * Version: 1.2.1
- * Location: components/vf-section-header
+ * Location: components/vf-core-
  */
 .vf-section-header__heading {
   font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
@@ -620,6 +620,6 @@ html:not(.vf-disable-deprecated) .vf-summary--profile-s .vf-summary__title {
 
 /*!
  * Component: @visual-framework/vf-news-container
- * Version: 1.0.0-beta.0
- * Location: components/vf-news-container
+ * Version: 1.0.0-beta.1
+ * Location: components/vf-core-
  */

--- a/wp-content/themes/vf-wp/assets/assets/vf-pagination/vf-pagination.css
+++ b/wp-content/themes/vf-wp/assets/assets/vf-pagination/vf-pagination.css
@@ -53,8 +53,8 @@
 /* stylelint-enable */
 /*!
  * Component: @visual-framework/vf-pagination
- * Version: 1.0.0-rc.0
- * Location: components/vf-pagination
+ * Version: 1.0.0-rc.1
+ * Location: components/vf-core-
  */
 .vf-pagination__list {
   display: -webkit-box;

--- a/wp-content/themes/vf-wp/assets/assets/vf-profile/vf-profile.css
+++ b/wp-content/themes/vf-wp/assets/assets/vf-profile/vf-profile.css
@@ -54,7 +54,7 @@
 /*!
  * Component: @visual-framework/vf-profile
  * Version: 1.2.0
- * Location: components/vf-profile
+ * Location: components/vf-core-
  */
 .vf-profile {
   -webkit-box-align: center;

--- a/wp-content/themes/vf-wp/assets/assets/vf-sass-utilities/vf-sass-utilities.css
+++ b/wp-content/themes/vf-wp/assets/assets/vf-sass-utilities/vf-sass-utilities.css
@@ -55,7 +55,7 @@ html:not(.vf-disable-deprecated) {
   /*!
   * Component: @visual-framework/vf-sass-utilities
   * Version: 1.0.1
-  * Location: components/vf-sass-utilities
+  * Location: components/vf-core-
   */
 }
 html:not(.vf-disable-deprecated) .vf-et-al {

--- a/wp-content/themes/vf-wp/assets/assets/vf-search/vf-search.css
+++ b/wp-content/themes/vf-wp/assets/assets/vf-search/vf-search.css
@@ -54,7 +54,7 @@
 /*!
  * Component: @visual-framework/vf-search
  * Version: 1.1.1
- * Location: components/vf-search
+ * Location: components/vf-core-
  */
 .vf-search--inline {
   display: -webkit-box;

--- a/wp-content/themes/vf-wp/assets/assets/vf-social-links/vf-social-links.css
+++ b/wp-content/themes/vf-wp/assets/assets/vf-social-links/vf-social-links.css
@@ -54,7 +54,7 @@
 /*!
  * Component: @visual-framework/vf-social-links
  * Version: 0.0.1
- * Location: components/vf-social-links
+ * Location: components/vf-core-
  */
 .vf-social-links__heading {
   font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;

--- a/wp-content/themes/vf-wp/assets/assets/vf-stack/vf-stack.css
+++ b/wp-content/themes/vf-wp/assets/assets/vf-stack/vf-stack.css
@@ -54,7 +54,7 @@
 /*!
  * Component: @visual-framework/vf-stack
  * Version: 1.1.1
- * Location: components/vf-stack
+ * Location: components/vf-core-
  */
 /*
  *

--- a/wp-content/themes/vf-wp/assets/assets/vf-summary/vf-summary.css
+++ b/wp-content/themes/vf-wp/assets/assets/vf-summary/vf-summary.css
@@ -62,7 +62,7 @@
 /*!
  * Component: @visual-framework/vf-summary
  * Version: 1.3.1
- * Location: components/vf-summary
+ * Location: components/vf-core-
  */
 .vf-summary {
   --vf-text-margin--bottom: 16px;

--- a/wp-content/themes/vf-wp/assets/assets/vf-table/vf-table.css
+++ b/wp-content/themes/vf-wp/assets/assets/vf-table/vf-table.css
@@ -54,7 +54,7 @@
 /*!
 * Component: @visual-framework/vf-table
 * Version: 1.0.1-1.1.1.0
-* Location: components/vf-table
+* Location: components/vf-core-
 */
 .vf-table {
   background-color: #ffffff;

--- a/wp-content/themes/vf-wp/assets/assets/vf-tabs/vf-tabs.css
+++ b/wp-content/themes/vf-wp/assets/assets/vf-tabs/vf-tabs.css
@@ -54,7 +54,7 @@
 /*!
  * Component: @visual-framework/vf-tabs
  * Version: 1.1.1
- * Location: components/vf-tabs
+ * Location: components/vf-core-
  */
 .vf-tabs__list {
   display: -webkit-inline-box;

--- a/wp-content/themes/vf-wp/assets/assets/vf-text/vf-text.css
+++ b/wp-content/themes/vf-wp/assets/assets/vf-text/vf-text.css
@@ -54,7 +54,7 @@
 /*!
  * Component: @visual-framework/vf-text
  * Version: 1.0.2
- * Location: components/vf-text
+ * Location: components/vf-core-
  */
 .vf-text-body a {
   border-bottom: none;

--- a/wp-content/themes/vf-wp/assets/assets/vf-u-fullbleed/vf-u-fullbleed.css
+++ b/wp-content/themes/vf-wp/assets/assets/vf-u-fullbleed/vf-u-fullbleed.css
@@ -54,7 +54,7 @@
 /*!
  * Component: @visual-framework/vf-u-fullbleed
  * Version: 1.1.0
- * Location: components/vf-u-fullbleed
+ * Location: components/vf-core-
  */
 /*
  *  1. we set the  variable for the @at-root directive here.

--- a/wp-content/themes/vf-wp/assets/assets/vf-utility-classes/vf-utility-classes.css
+++ b/wp-content/themes/vf-wp/assets/assets/vf-utility-classes/vf-utility-classes.css
@@ -54,7 +54,7 @@
 /*!
  * Component: @visual-framework/vf-utility-classes
  * Version: 1.2.0
- * Location: components/vf-utility-classes
+ * Location: components/vf-core-
  */
 .vf-u-clearfix::before {
   content: "";

--- a/wp-content/themes/vf-wp/assets/assets/vf-video-container/vf-video-container.css
+++ b/wp-content/themes/vf-wp/assets/assets/vf-video-container/vf-video-container.css
@@ -54,7 +54,7 @@
 /*!
 * Component: @visual-framework/embl-grid
 * Version: 2.0.4
-* Location: components/embl-grid
+* Location: components/vf-core-
 */
 .embl-grid {
   margin-bottom: 48px;
@@ -146,7 +146,7 @@
 /*!
  * Component: @visual-framework/vf-section-header
  * Version: 1.2.1
- * Location: components/vf-section-header
+ * Location: components/vf-core-
  */
 .vf-section-header__heading {
   font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
@@ -235,8 +235,8 @@
 
 /*!
  * Component: @visual-framework/vf-video
- * Version: 1.0.0-beta.0
- * Location: components/vf-video
+ * Version: 1.0.0-beta.1
+ * Location: components/vf-core-
  */
 .vf-video {
   height: 0;
@@ -256,7 +256,7 @@
 /*!
  * Component: @visual-framework/vf-video-teaser
  * Version: 1.0.0
- * Location: components/vf-video-teaser
+ * Location: components/vf-core-
  */
 .vf-video-teaser__image {
   display: block;
@@ -278,6 +278,6 @@
 
 /*!
  * Component: @visual-framework/vf-video-container
- * Version: 1.0.0-beta.0
- * Location: components/vf-video-container
+ * Version: 1.0.0-beta.1
+ * Location: components/vf-core-
  */

--- a/wp-content/themes/vf-wp/assets/assets/vf-video-teaser/vf-video-teaser.css
+++ b/wp-content/themes/vf-wp/assets/assets/vf-video-teaser/vf-video-teaser.css
@@ -53,8 +53,8 @@
 /* stylelint-enable */
 /*!
  * Component: @visual-framework/vf-heading
- * Version: 1.0.0-rc.1
- * Location: components/vf-heading
+ * Version: 1.0.0
+ * Location: components/vf-core-
  */
 .vf-text {
   margin: 0 0 16px 0;
@@ -127,7 +127,7 @@
 /*!
  * Component: @visual-framework/vf-link
  * Version: 1.0.3
- * Location: components/vf-link
+ * Location: components/vf-core-
  */
 .vf-link {
   border-bottom: none;
@@ -184,7 +184,7 @@
 /*!
  * Component: @visual-framework/vf-video-teaser
  * Version: 1.0.0
- * Location: components/vf-video-teaser
+ * Location: components/vf-core-
  */
 .vf-video-teaser__image {
   display: block;

--- a/wp-content/themes/vf-wp/assets/assets/vf-video/vf-video.css
+++ b/wp-content/themes/vf-wp/assets/assets/vf-video/vf-video.css
@@ -53,8 +53,8 @@
 /* stylelint-enable */
 /*!
  * Component: @visual-framework/vf-video
- * Version: 1.0.0-beta.0
- * Location: components/vf-video
+ * Version: 1.0.0-beta.1
+ * Location: components/vf-core-
  */
 .vf-video {
   height: 0;

--- a/wp-content/themes/vf-wp/assets/assets/vfwp-admin/vfwp-admin.css
+++ b/wp-content/themes/vf-wp/assets/assets/vfwp-admin/vfwp-admin.css
@@ -52,112 +52,327 @@
 
 /* stylelint-enable */
 /*!
- * Component: @visual-framework/vf-font-plex-sans
- * Version: 1.1.0
+ * Component: @visual-framework/vf-content
+ * Version: 1.2.2
  * Location: components/vf-core-
  */
-@font-face {
-  font-family: "IBM Plex Sans";
-  font-style: normal;
-  font-weight: 700;
-  src: local("IBM Plex Sans Bold"), local("IBMPlexSans-Bold"), url("../assets/vf-font-plex-sans/assets/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-Bold.woff") format("woff");
-}
-@font-face {
-  font-family: "IBM Plex Sans";
-  font-style: italic;
-  font-weight: 700;
-  src: local("IBM Plex Sans Bold Italic"), local("IBMPlexSans-BoldItalic"), url("../assets/vf-font-plex-sans/assets/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-BoldItalic.woff") format("woff");
-}
-@font-face {
-  font-family: "IBM Plex Sans";
-  font-style: normal;
-  font-weight: 200;
-  src: local("IBM Plex Sans ExtraLight"), local("IBMPlexSans-ExtraLight"), url("../assets/vf-font-plex-sans/assets/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-ExtraLight.woff") format("woff");
-}
-@font-face {
-  font-family: "IBM Plex Sans";
-  font-style: italic;
-  font-weight: 200;
-  src: local("IBM Plex Sans ExtraLight Italic"), local("IBMPlexSans-ExtraLightItalic"), url("../assets/vf-font-plex-sans/assets/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-ExtraLightItalic.woff") format("woff");
-}
-@font-face {
-  font-family: "IBM Plex Sans";
-  font-style: italic;
-  font-weight: 400;
-  src: local("IBM Plex Sans Italic"), local("IBMPlexSans-Italic"), url("../assets/vf-font-plex-sans/assets/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-Italic.woff") format("woff");
-}
-@font-face {
-  font-family: "IBM Plex Sans";
-  font-style: normal;
-  font-weight: 300;
-  src: local("IBM Plex Sans Light"), local("IBMPlexSans-Light"), url("../assets/vf-font-plex-sans/assets/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-Light.woff") format("woff");
-}
-@font-face {
-  font-family: "IBM Plex Sans";
-  font-style: italic;
-  font-weight: 300;
-  src: local("IBM Plex Sans Light Italic"), local("IBMPlexSans-LightItalic"), url("../assets/vf-font-plex-sans/assets/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-LightItalic.woff") format("woff");
-}
-@font-face {
-  font-family: "IBM Plex Sans";
-  font-style: normal;
-  font-weight: 500;
-  src: local("IBM Plex Sans Medium"), local("IBMPlexSans-Medium"), url("../assets/vf-font-plex-sans/assets/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-Medium.woff") format("woff");
-}
-@font-face {
-  font-family: "IBM Plex Sans";
-  font-style: italic;
-  font-weight: 500;
-  src: local("IBM Plex Sans Medium Italic"), local("IBMPlexSans-MediumItalic"), url("../assets/vf-font-plex-sans/assets/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-MediumItalic.woff") format("woff");
-}
-@font-face {
-  font-family: "IBM Plex Sans";
-  font-style: normal;
-  font-weight: 400;
-  src: local("IBM Plex Sans"), local("IBMPlexSans"), url("../assets/vf-font-plex-sans/assets/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-Regular.woff") format("woff");
-}
-@font-face {
-  font-family: "IBM Plex Sans";
-  font-style: normal;
-  font-weight: 600;
-  src: local("IBM Plex Sans SemiBold"), local("IBMPlexSans-SemiBold"), url("../assets/vf-font-plex-sans/assets/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-SemiBold.woff") format("woff");
-}
-@font-face {
-  font-family: "IBM Plex Sans";
-  font-style: italic;
-  font-weight: 600;
-  src: local("IBM Plex Sans SemiBold Italic"), local("IBMPlexSans-SemiBoldItalic"), url("../assets/vf-font-plex-sans/assets/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-SemiBoldItalic.woff") format("woff");
-}
-@font-face {
-  font-family: "IBM Plex Sans";
-  font-style: normal;
-  font-weight: 450;
-  src: local("IBM Plex Sans Text"), local("IBMPlexSans-Text"), url("../assets/vf-font-plex-sans/assets/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-Text.woff") format("woff");
-}
-@font-face {
-  font-family: "IBM Plex Sans";
-  font-style: italic;
-  font-weight: 450;
-  src: local("IBM Plex Sans Text Italic"), local("IBMPlexSans-TextItalic"), url("../assets/vf-font-plex-sans/assets/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-TextItalic.woff") format("woff");
-}
-@font-face {
-  font-family: "IBM Plex Sans";
-  font-style: normal;
-  font-weight: 100;
-  src: local("IBM Plex Sans Thin"), local("IBMPlexSans-Thin"), url("../assets/vf-font-plex-sans/assets/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-Thin.woff") format("woff");
-}
-@font-face {
-  font-family: "IBM Plex Sans";
-  font-style: italic;
-  font-weight: 100;
-  src: local("IBM Plex Sans Thin Italic"), local("IBMPlexSans-ThinItalic"), url("../assets/vf-font-plex-sans/assets/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-ThinItalic.woff") format("woff");
-}
-.vf-font-plex-sans {
+.vf-content h1:not([class*=vf-]), .editor-styles-wrapper h1:not([class*=vf-]) {
   font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
-  font-size: 16px;
-  font-weight: 400;
-  line-height: 1.71;
+  font-size: 42px;
+  font-weight: 700;
+  line-height: 1.547;
   margin: 0 0 0 0;
+}
+.vf-content h1:not([class*=vf-]) + small, .editor-styles-wrapper h1:not([class*=vf-]) + small {
+  margin-bottom: 35px;
+  margin-top: 22px;
+}
+.vf-content h1:not([class*=vf-]) b, .editor-styles-wrapper h1:not([class*=vf-]) b,
+.vf-content h1:not([class*=vf-]) strong,
+.editor-styles-wrapper h1:not([class*=vf-]) strong {
+  font-weight: inherit;
+}
+.vf-content h2:not([class*=vf-]), .editor-styles-wrapper h2:not([class*=vf-]) {
+  font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
+  font-size: 30px;
+  font-weight: 500;
+  line-height: 1.333;
+  margin: 0 0 39px 0;
+  margin-top: 0;
+  padding-top: 13px;
+}
+.vf-content h2:not([class*=vf-]) b, .editor-styles-wrapper h2:not([class*=vf-]) b,
+.vf-content h2:not([class*=vf-]) strong,
+.editor-styles-wrapper h2:not([class*=vf-]) strong {
+  font-weight: inherit;
+}
+.vf-content h3:not([class*=vf-]), .editor-styles-wrapper h3:not([class*=vf-]) {
+  font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
+  font-size: 24px;
+  font-weight: 500;
+  line-height: 1.333;
+  margin: 0 0 13px 0;
+  margin-top: 24px;
+}
+.vf-content h3:not([class*=vf-]) b, .editor-styles-wrapper h3:not([class*=vf-]) b,
+.vf-content h3:not([class*=vf-]) strong,
+.editor-styles-wrapper h3:not([class*=vf-]) strong {
+  font-weight: inherit;
+}
+.vf-content h4:not([class*=vf-]), .editor-styles-wrapper h4:not([class*=vf-]) {
+  font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
+  font-size: 21px;
+  font-weight: 500;
+  line-height: 1.29;
+  margin: 0 0 13px 0;
+  margin-top: 24px;
+}
+.vf-content h4:not([class*=vf-]) b, .editor-styles-wrapper h4:not([class*=vf-]) b,
+.vf-content h4:not([class*=vf-]) strong,
+.editor-styles-wrapper h4:not([class*=vf-]) strong {
+  font-weight: inherit;
+}
+.vf-content h5:not([class*=vf-]), .editor-styles-wrapper h5:not([class*=vf-]) {
+  font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
+  font-size: 19px;
+  font-weight: 500;
+  line-height: 1.5;
+  margin: 0 0 13px 0;
+  margin-top: 24px;
+}
+.vf-content h5:not([class*=vf-]) b, .editor-styles-wrapper h5:not([class*=vf-]) b,
+.vf-content h5:not([class*=vf-]) strong,
+.editor-styles-wrapper h5:not([class*=vf-]) strong {
+  font-weight: inherit;
+}
+.vf-content h6:not([class*=vf-]), .editor-styles-wrapper h6:not([class*=vf-]) {
+  font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
+  font-size: 19px;
+  font-weight: 500;
+  line-height: 1.5;
+  margin: 0 0 13px 0;
+  margin-top: 24px;
+}
+.vf-content h6:not([class*=vf-]) b, .editor-styles-wrapper h6:not([class*=vf-]) b,
+.vf-content h6:not([class*=vf-]) strong,
+.editor-styles-wrapper h6:not([class*=vf-]) strong {
+  font-weight: inherit;
+}
+.vf-content p:not([class*=vf-]), .editor-styles-wrapper p:not([class*=vf-]) {
+  font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
+  font-size: 19px;
+  font-weight: 400;
+  line-height: 1.421;
+  margin: 0 0 24px 0;
+}
+.vf-content .vf-link, .editor-styles-wrapper .vf-link,
+.vf-content a:not([class*=vf-]),
+.editor-styles-wrapper a:not([class*=vf-]) {
+  border-bottom: none;
+  text-decoration: none;
+  color: #3b6fb6;
+}
+.vf-content .vf-link:visited, .editor-styles-wrapper .vf-link:visited,
+.vf-content a:not([class*=vf-]):visited,
+.editor-styles-wrapper a:not([class*=vf-]):visited {
+  color: #734595;
+  border-bottom: none;
+}
+.vf-content .vf-link:visited:hover, .editor-styles-wrapper .vf-link:visited:hover,
+.vf-content a:not([class*=vf-]):visited:hover,
+.editor-styles-wrapper a:not([class*=vf-]):visited:hover {
+  color: #734595;
+  text-decoration: underline;
+}
+.vf-content .vf-link:hover, .editor-styles-wrapper .vf-link:hover,
+.vf-content a:not([class*=vf-]):hover,
+.editor-styles-wrapper a:not([class*=vf-]):hover {
+  color: #193f90;
+  border-bottom: none;
+  text-decoration: underline;
+}
+.vf-content small:not([class*=vf-]), .editor-styles-wrapper small:not([class*=vf-]) {
+  font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 1.57;
+  margin: 0 0 16px 0;
+  margin: 0 0 var(--vf-text-margin--bottom, 16px) 0;
+  display: block;
+}
+.vf-content ol:not([class*=vf-]), .editor-styles-wrapper ol:not([class*=vf-]) {
+  margin: 0;
+  list-style-type: decimal;
+  padding-left: 16px;
+  padding-left: 20px;
+}
+.vf-list--ordered__item {
+  margin-bottom: 16px;
+}
+
+.vf-content ul:not([class*=vf-]), .editor-styles-wrapper ul:not([class*=vf-]) {
+  margin: 0;
+  padding-left: 16px;
+  list-style-type: disc;
+  padding-left: 20px;
+}
+.vf-list--unordered__item {
+  margin-bottom: 16px;
+}
+
+.vf-content li:not([class*=vf-]), .editor-styles-wrapper li:not([class*=vf-]) {
+  font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
+  font-size: 19px;
+  font-weight: 400;
+  line-height: 1.421;
+  margin: 0 0 16px 0;
+  margin: 0 0 var(--vf-text-margin--bottom, 16px) 0;
+  margin-bottom: 8px;
+}
+.vf-content li:not([class*=vf-]) > ul:not([class*=vf-]), .editor-styles-wrapper li:not([class*=vf-]) > ul:not([class*=vf-]),
+.vf-content li:not([class*=vf-]) > ol:not([class*=vf-]),
+.editor-styles-wrapper li:not([class*=vf-]) > ol:not([class*=vf-]) {
+  margin-top: 8px;
+}
+.vf-content li:not([class*=vf-]):last-of-type, .editor-styles-wrapper li:not([class*=vf-]):last-of-type {
+  margin-bottom: 16px;
+}
+.vf-content hr:not([class*=vf-]), .editor-styles-wrapper hr:not([class*=vf-]) {
+  background-color: #d8d8d8;
+  margin: 0 8px;
+  height: 1px;
+  border: none;
+}
+.vf-content code:not([class*=vf-]), .editor-styles-wrapper code:not([class*=vf-]) {
+  padding-left: 3px;
+  padding-right: 3px;
+}
+.vf-content blockquote:not([class*=vf-]), .editor-styles-wrapper blockquote:not([class*=vf-]) {
+  font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
+  font-size: 19px;
+  font-weight: 400;
+  line-height: 1.421;
+  margin: 0 0 16px 0;
+  margin: 0 0 var(--vf-text-margin--bottom, 16px) 0;
+  margin: 0 0 0 0;
+  border: 0;
+  padding: 10px 8px 10px 32px;
+  position: relative;
+}
+.vf-content blockquote:not([class*=vf-])::before, .editor-styles-wrapper blockquote:not([class*=vf-])::before {
+  content: "";
+  border-left: 4px solid #d0d0ce;
+  position: absolute;
+  left: 12px;
+  height: 100%;
+  top: 0;
+}
+.vf-content blockquote:not([class*=vf-]) p:last-of-type:not([class*=vf-]), .editor-styles-wrapper blockquote:not([class*=vf-]) p:last-of-type:not([class*=vf-]) {
+  margin-bottom: 0;
+}
+.vf-content table:not([class*=vf-]), .editor-styles-wrapper table:not([class*=vf-]) {
+  background-color: #ffffff;
+  border-collapse: collapse;
+}
+.vf-content table:not([class*=vf-]) caption, .editor-styles-wrapper table:not([class*=vf-]) caption {
+  font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
+  font-size: 21px;
+  font-weight: 500;
+  line-height: 1.29;
+  margin: 0 0 16px 0;
+  margin: 0 0 var(--vf-text-margin--bottom, 16px) 0;
+  text-align: left;
+}
+.vf-content table:not([class*=vf-]) thead, .editor-styles-wrapper table:not([class*=vf-]) thead {
+  background-color: #d0d0ce;
+}
+.vf-content table:not([class*=vf-]) thead th, .editor-styles-wrapper table:not([class*=vf-]) thead th {
+  font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
+  font-size: 19px;
+  font-weight: 500;
+  line-height: 1.5;
+  margin: 0 0 0 0;
+  padding: 8px 16px;
+  text-align: left;
+}
+.vf-content table:not([class*=vf-]) td, .editor-styles-wrapper table:not([class*=vf-]) td {
+  font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
+  font-size: 19px;
+  font-weight: 400;
+  line-height: 1.421;
+  margin: 0 0 0 0;
+  padding: 8px 16px;
+  text-align: left;
+  vertical-align: top;
+}
+.vf-content table:not([class*=vf-]) tr:nth-of-type(even), .editor-styles-wrapper table:not([class*=vf-]) tr:nth-of-type(even) {
+  background-color: #f3f3f3;
+}
+.vf-content table:not([class*=vf-]) tfoot, .editor-styles-wrapper table:not([class*=vf-]) tfoot {
+  background-color: #d0d0ce;
+  border-top: 1px solid #000000;
+}
+.vf-content table:not([class*=vf-]) tfoot td, .editor-styles-wrapper table:not([class*=vf-]) tfoot td {
+  padding: 8px 16px;
+}
+.vf-content figcaption:not([class*=vf-]), .editor-styles-wrapper figcaption:not([class*=vf-]),
+.vf-content cite:not([class*=vf-]),
+.editor-styles-wrapper cite:not([class*=vf-]) {
+  font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 1.57;
+  margin: 0 0 16px 0;
+  margin: 0 0 var(--vf-text-margin--bottom, 16px) 0;
+  color: #707372;
+  font-style: italic;
+}
+.vf-content .vf-video, .editor-styles-wrapper .vf-video {
+  margin-bottom: 32px;
+}
+.vf-content .vf-figure--align-inline-start, .editor-styles-wrapper .vf-figure--align-inline-start {
+  margin-bottom: 32px;
+  margin-right: 32px;
+}
+.vf-content .vf-figure--align-inline-end, .editor-styles-wrapper .vf-figure--align-inline-end {
+  margin-bottom: 32px;
+  margin-left: 32px;
+}
+
+.vf-content__standfirst {
+  font-size: 21px;
+  line-height: 31px;
+  margin-bottom: 46px;
+  margin-top: 0;
+}
+.vf-content__standfirst + .vf-content__standfirst {
+  margin-bottom: 24px;
+}
+.vf-content__standfirst + small {
+  margin-bottom: 42px;
+}
+
+[class*="--dark"].vf-content .vf-link, [class*="--dark"].editor-styles-wrapper .vf-link,
+[class*="--dark"].vf-content a:not([class*=vf-]),
+[class*="--dark"].editor-styles-wrapper a:not([class*=vf-]),
+.vf-content > [class*=dark] .vf-link,
+.editor-styles-wrapper > [class*=dark] .vf-link,
+.vf-content > [class*=dark] a:not([class*=vf-]),
+.editor-styles-wrapper > [class*=dark] a:not([class*=vf-]) {
+  border-bottom: none;
+  text-decoration: none;
+  color: #a8d2ff;
+}
+[class*="--dark"].vf-content .vf-link:visited, [class*="--dark"].editor-styles-wrapper .vf-link:visited,
+[class*="--dark"].vf-content a:not([class*=vf-]):visited,
+[class*="--dark"].editor-styles-wrapper a:not([class*=vf-]):visited,
+.vf-content > [class*=dark] .vf-link:visited,
+.editor-styles-wrapper > [class*=dark] .vf-link:visited,
+.vf-content > [class*=dark] a:not([class*=vf-]):visited,
+.editor-styles-wrapper > [class*=dark] a:not([class*=vf-]):visited {
+  color: #cba3d8;
+  border-bottom: none;
+}
+[class*="--dark"].vf-content .vf-link:visited:hover, [class*="--dark"].editor-styles-wrapper .vf-link:visited:hover,
+[class*="--dark"].vf-content a:not([class*=vf-]):visited:hover,
+[class*="--dark"].editor-styles-wrapper a:not([class*=vf-]):visited:hover,
+.vf-content > [class*=dark] .vf-link:visited:hover,
+.editor-styles-wrapper > [class*=dark] .vf-link:visited:hover,
+.vf-content > [class*=dark] a:not([class*=vf-]):visited:hover,
+.editor-styles-wrapper > [class*=dark] a:not([class*=vf-]):visited:hover {
+  color: #cba3d8;
+  text-decoration: underline;
+}
+[class*="--dark"].vf-content .vf-link:hover, [class*="--dark"].editor-styles-wrapper .vf-link:hover,
+[class*="--dark"].vf-content a:not([class*=vf-]):hover,
+[class*="--dark"].editor-styles-wrapper a:not([class*=vf-]):hover,
+.vf-content > [class*=dark] .vf-link:hover,
+.editor-styles-wrapper > [class*=dark] .vf-link:hover,
+.vf-content > [class*=dark] a:not([class*=vf-]):hover,
+.editor-styles-wrapper > [class*=dark] a:not([class*=vf-]):hover {
+  color: #a8d2ff;
+  border-bottom: none;
+  text-decoration: underline;
 }
 
 /*!
@@ -172,6 +387,12 @@
 .wp-list-table .column-vf_hash,
 .wp-list-table .column-vf_modified {
   width: 10%;
+}
+
+.wp-block {
+  max-width: 780px;
+  margin-left: auto !important;
+  margin-right: auto !important;
 }
 
 .post-type-vf_block .edit-post-visual-editor,
@@ -200,10 +421,6 @@
       -ms-flex-positive: 0;
           flex-grow: 0;
 }
-.post-type-vf_block .edit-post-layout__metaboxes .acf-hndle-cog,
-.post-type-vf_container .edit-post-layout__metaboxes .acf-hndle-cog {
-  display: none !important;
-}
 
 .editor-post-title__block {
   --vf-text-margin--bottom: 0;
@@ -217,63 +434,11 @@
   margin: 0 0 var(--vf-text-margin--bottom, 16px) 0;
 }
 
-.editor-styles-wrapper h1 {
-  font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
-  font-size: 42px;
-  font-weight: 700;
-  line-height: 1.547;
-  margin: 0 0 16px 0;
-  margin: 0 0 var(--vf-text-margin--bottom, 16px) 0;
+.editor-styles-wrapper .vf-details[open] .vf-details--summary {
+  pointer-events: none;
 }
-.editor-styles-wrapper h2 {
-  font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
-  font-size: 30px;
-  font-weight: 500;
-  line-height: 1.333;
-  margin: 0 0 16px 0;
-  margin: 0 0 var(--vf-text-margin--bottom, 16px) 0;
-}
-.editor-styles-wrapper h3 {
-  font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
-  font-size: 24px;
-  font-weight: 500;
-  line-height: 1.333;
-  margin: 0 0 16px 0;
-  margin: 0 0 var(--vf-text-margin--bottom, 16px) 0;
-}
-.editor-styles-wrapper h4 {
-  font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
-  font-size: 21px;
-  font-weight: 500;
-  line-height: 1.29;
-  margin: 0 0 16px 0;
-  margin: 0 0 var(--vf-text-margin--bottom, 16px) 0;
-}
-.editor-styles-wrapper h5 {
-  font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
-  font-size: 19px;
-  font-weight: 500;
-  line-height: 1.5;
-  margin: 0 0 16px 0;
-  margin: 0 0 var(--vf-text-margin--bottom, 16px) 0;
-}
-.editor-styles-wrapper h6 {
-  font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
-  font-size: 19px;
-  font-weight: 500;
-  line-height: 1.5;
-  margin: 0 0 16px 0;
-  margin: 0 0 var(--vf-text-margin--bottom, 16px) 0;
-}
-.editor-styles-wrapper p {
-  font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
-  font-size: 19px;
-  font-weight: 400;
-  line-height: 1.421;
-  margin: 0 0 16px 0;
-  margin: 0 0 var(--vf-text-margin--bottom, 16px) 0;
-}
-.editor-styles-wrapper .has-extra-large-font-size {
+
+.block-editor .editor-styles-wrapper .has-extra-large-font-size {
   font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
   font-size: 32px;
   font-weight: 500;
@@ -281,7 +446,7 @@
   margin: 0 0 16px 0;
   margin: 0 0 var(--vf-text-margin--bottom, 16px) 0;
 }
-.editor-styles-wrapper .has-large-font-size {
+.block-editor .editor-styles-wrapper .has-large-font-size {
   font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
   font-size: 19px;
   font-weight: 400;
@@ -289,7 +454,7 @@
   margin: 0 0 16px 0;
   margin: 0 0 var(--vf-text-margin--bottom, 16px) 0;
 }
-.editor-styles-wrapper .has-regular-font-size {
+.block-editor .editor-styles-wrapper .has-regular-font-size {
   font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
   font-size: 16px;
   font-weight: 400;
@@ -297,7 +462,7 @@
   margin: 0 0 16px 0;
   margin: 0 0 var(--vf-text-margin--bottom, 16px) 0;
 }
-.editor-styles-wrapper .has-small-font-size {
+.block-editor .editor-styles-wrapper .has-small-font-size {
   font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
   font-size: 14px;
   font-weight: 500;
@@ -305,99 +470,11 @@
   margin: 0 0 16px 0;
   margin: 0 0 var(--vf-text-margin--bottom, 16px) 0;
 }
-.editor-styles-wrapper .has-extra-small-font-size {
+.block-editor .editor-styles-wrapper .has-extra-small-font-size {
   font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
   font-size: 14px;
   font-weight: 400;
   line-height: 1.57;
   margin: 0 0 16px 0;
   margin: 0 0 var(--vf-text-margin--bottom, 16px) 0;
-}
-
-.wp-block {
-  max-width: 780px;
-}
-.wp-block .block-editor-default-block-appender {
-  --vf-text-margin--bottom: 0;
-}
-.wp-block .block-editor-default-block-appender .block-editor-default-block-appender__content {
-  font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
-  font-size: 19px;
-  font-weight: 400;
-  line-height: 1.421;
-  margin: 0 0 16px 0;
-  margin: 0 0 var(--vf-text-margin--bottom, 16px) 0;
-}
-
-.wp-block[data-type="core/heading"] {
-  --vf-text-margin--bottom: 0;
-}
-
-.wp-block[data-type="core/paragraph"] {
-  --vf-text-margin--bottom: 0;
-}
-
-.wp-block[data-type="core/list"] {
-  --vf-text-margin--bottom: 0;
-}
-.wp-block[data-type="core/list"] .editor-rich-text li {
-  font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
-  font-size: 19px;
-  font-weight: 400;
-  line-height: 1.421;
-  margin: 0 0 16px 0;
-  margin: 0 0 var(--vf-text-margin--bottom, 16px) 0;
-  margin-bottom: 8px;
-}
-
-.wp-block[data-type="core/quote"] {
-  --vf-text-margin--bottom: 16px;
-}
-.wp-block[data-type="core/quote"] .editor-rich-text p {
-  font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
-  font-size: 19px;
-  font-weight: 400;
-  line-height: 1.421;
-  margin: 0 0 16px 0;
-  margin: 0 0 var(--vf-text-margin--bottom, 16px) 0;
-}
-.wp-block[data-type="core/quote"] .wp-block-quote__citation {
-  font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
-  font-size: 14px;
-  font-weight: 500;
-  line-height: 1.57;
-  margin: 0 0 16px 0;
-  margin: 0 0 var(--vf-text-margin--bottom, 16px) 0;
-}
-.wp-block[data-type="core/quote"] .wp-block-quote {
-  border-left: 4px solid #d0d0ce;
-}
-
-.wp-block[data-type="core/table"] {
-  --vf-text-margin--bottom: 0;
-}
-.wp-block[data-type="core/table"] .editor-rich-text {
-  font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
-  font-size: 16px;
-  font-weight: 400;
-  line-height: 1.71;
-  margin: 0 0 16px 0;
-  margin: 0 0 var(--vf-text-margin--bottom, 16px) 0;
-}
-
-.wp-block[data-type="core/archives"],
-.wp-block[data-type="core/categories"],
-.wp-block[data-type="core/latest-posts"] {
-  --vf-text-margin--bottom: 0;
-}
-.wp-block[data-type="core/archives"] li,
-.wp-block[data-type="core/categories"] li,
-.wp-block[data-type="core/latest-posts"] li {
-  font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;
-  font-size: 19px;
-  font-weight: 400;
-  line-height: 1.421;
-  margin: 0 0 16px 0;
-  margin: 0 0 var(--vf-text-margin--bottom, 16px) 0;
-  margin-bottom: 8px;
 }

--- a/wp-content/themes/vf-wp/assets/assets/vfwp-admin/vfwp-admin.css
+++ b/wp-content/themes/vf-wp/assets/assets/vfwp-admin/vfwp-admin.css
@@ -54,7 +54,7 @@
 /*!
  * Component: @visual-framework/vf-font-plex-sans
  * Version: 1.1.0
- * Location: components/vf-font-plex-sans
+ * Location: components/vf-core-
  */
 @font-face {
   font-family: "IBM Plex Sans";

--- a/wp-content/themes/vf-wp/blocks/vfwp-debug/acf.json
+++ b/wp-content/themes/vf-wp/blocks/vfwp-debug/acf.json
@@ -1,0 +1,43 @@
+{
+    "key": "group_5f607a3124d59",
+    "title": "Debug",
+    "fields": [
+        {
+            "key": "field_5f607bf9cb2f3",
+            "label": "Text",
+            "name": "text",
+            "type": "text",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "default_value": "",
+            "placeholder": "",
+            "prepend": "",
+            "append": "",
+            "maxlength": ""
+        }
+    ],
+    "location": [
+        [
+            {
+                "param": "block",
+                "operator": "==",
+                "value": "acf\/vfwp-debug"
+            }
+        ]
+    ],
+    "menu_order": 0,
+    "position": "normal",
+    "style": "default",
+    "label_placement": "top",
+    "instruction_placement": "label",
+    "hide_on_screen": "",
+    "active": true,
+    "description": "VF-WP Debug ACF Gutenberg block",
+    "modified": 1600161019
+}

--- a/wp-content/themes/vf-wp/blocks/vfwp-debug/index.php
+++ b/wp-content/themes/vf-wp/blocks/vfwp-debug/index.php
@@ -1,0 +1,45 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) exit;
+
+if ( ! class_exists('VFWP_Debug') ) :
+
+class VFWP_Debug extends VFWP_Block {
+
+  public function __construct() {
+    parent::__construct(__FILE__);
+  }
+
+  /**
+   * Return the block name
+   */
+  static public function get_name() {
+    return 'vfwp-debug';
+  }
+
+  /**
+   * Return Gutenberg block registration configuration
+   * https://www.advancedcustomfields.com/resources/acf_register_block_type/
+   * https://developer.wordpress.org/block-editor/developers/block-api/block-registration/
+   */
+  public function get_config() {
+    return array(
+      'name'     => $this->get_name(),
+      'title'    => 'Debug',
+      'category' => 'vf/wp',
+      'supports' => array(
+        'align'           => false,
+        'customClassName' => false,
+        'jsx'             => true
+      )
+    );
+  }
+
+} // VFWP_Debug
+
+// Initialize one instance
+$vfwp_example = new VFWP_Debug();
+
+endif;
+
+?>

--- a/wp-content/themes/vf-wp/blocks/vfwp-debug/index.php
+++ b/wp-content/themes/vf-wp/blocks/vfwp-debug/index.php
@@ -28,9 +28,10 @@ class VFWP_Debug extends VFWP_Block {
       'title'    => 'Debug',
       'category' => 'vf/wp',
       'supports' => array(
+        'vf/renderIFrame' => false,
+        'vf/innerBlocks'  => true,
         'align'           => false,
-        'customClassName' => false,
-        'jsx'             => true
+        'customClassName' => false
       )
     );
   }

--- a/wp-content/themes/vf-wp/blocks/vfwp-debug/template.php
+++ b/wp-content/themes/vf-wp/blocks/vfwp-debug/template.php
@@ -1,0 +1,29 @@
+<?php
+
+// Block preview in Gutenberg editor
+$is_preview = isset($is_preview) && $is_preview;
+
+$text = get_field('text');
+
+?>
+<div>
+  <h2>Example Block</h2>
+  <p><b>Text field:</b> <?php echo esc_html($text); ?></p>
+  <div>
+    <h3>Inner Blocks</h3>
+    <?php if ($is_preview) { ?>
+      <div class="vf-banner vf-banner--alert vf-banner--info">
+        <div class="vf-banner__content">
+          <p class="vf-banner__text">
+            <?php esc_html_e('Content placeholder.', 'vfwp'); ?>
+          </p>
+        </div>
+      </div>
+      <!--/vf-banner-->
+    <?php } else { ?>
+    <div class="vfwp-innerblocks">
+      <InnerBlocks />
+    <div>
+    <?php } ?>
+  </div>
+</div>

--- a/wp-content/themes/vf-wp/blocks/vfwp-debug/template.php
+++ b/wp-content/themes/vf-wp/blocks/vfwp-debug/template.php
@@ -7,23 +7,14 @@ $text = get_field('text');
 
 ?>
 <div>
-  <h2>Example Block</h2>
-  <p><b>Text field:</b> <?php echo esc_html($text); ?></p>
-  <div>
-    <h3>Inner Blocks</h3>
-    <?php if ($is_preview) { ?>
-      <div class="vf-banner vf-banner--alert vf-banner--info">
-        <div class="vf-banner__content">
-          <p class="vf-banner__text">
-            <?php esc_html_e('Content placeholder.', 'vfwp'); ?>
-          </p>
-        </div>
-      </div>
-      <!--/vf-banner-->
-    <?php } else { ?>
-    <div class="vfwp-innerblocks">
-      <InnerBlocks />
-    <div>
-    <?php } ?>
+  <h2>Example Block </h2>
+  <p>
+    <b>Text field:</b> <?php echo esc_html($text); ?>
+    <br><b>Preview:</b> <?php var_dump($is_preview); ?>
+  </p>
+  <h3>Inner Blocks</h3>
+  <div class="vfwp-innerblocks">
+    <InnerBlocks />
   </div>
+  <p><b>End debug block</b></p>
 </div>

--- a/wp-content/themes/vf-wp/blocks/vfwp-details/index.php
+++ b/wp-content/themes/vf-wp/blocks/vfwp-details/index.php
@@ -29,9 +29,9 @@ class VFWP_Details extends VFWP_Block {
       'title'    => 'Details',
       'category' => 'vf/wp',
       'supports' => array(
+        // 'vf/innerBlocks'  => true,
         'align'           => false,
         'customClassName' => false,
-        'jsx'             => true
       )
     );
   }

--- a/wp-content/themes/vf-wp/blocks/vfwp-details/index.php
+++ b/wp-content/themes/vf-wp/blocks/vfwp-details/index.php
@@ -30,7 +30,8 @@ class VFWP_Details extends VFWP_Block {
       'category' => 'vf/wp',
       'supports' => array(
         'align'           => false,
-        'customClassName' => false
+        'customClassName' => false,
+        'jsx'             => true
       )
     );
   }

--- a/wp-content/themes/vf-wp/blocks/vfwp-details/index.php
+++ b/wp-content/themes/vf-wp/blocks/vfwp-details/index.php
@@ -29,7 +29,8 @@ class VFWP_Details extends VFWP_Block {
       'title'    => 'Details',
       'category' => 'vf/wp',
       'supports' => array(
-        // 'vf/innerBlocks'  => true,
+        'vf/renderIFrame' => false,
+        'vf/innerBlocks'  => true,
         'align'           => false,
         'customClassName' => false,
       )

--- a/wp-content/themes/vf-wp/blocks/vfwp-details/template.php
+++ b/wp-content/themes/vf-wp/blocks/vfwp-details/template.php
@@ -25,17 +25,22 @@ $admin_banner = function($message, $modifier = 'info') use ($is_preview) {
 
 if (
   vf_html_empty($title)
-  && vf_html_empty($summary)
 ) {
-  $admin_banner(__('Please enter content for this block.', 'vfwp'));
+  $admin_banner(__('Please enter a title for this block.', 'vfwp'));
   return;
 }
 ?>
 
-<details class="vf-details">
+<details class="vf-details"<?php if ($is_preview) { echo ' open'; } ?>>
 <summary class="vf-details--summary">
 <?php echo esc_html($title); ?>
 </summary>
-<?php echo wpautop($summary); ?>
+<?php
+if ( ! empty($summary)) {
+  echo wpautop($summary);
+}
+?>
+<?php if ( ! $is_preview) { ?>
+<InnerBlocks />
+<?php } ?>
 </details>
-

--- a/wp-content/themes/vf-wp/blocks/vfwp-details/template.php
+++ b/wp-content/themes/vf-wp/blocks/vfwp-details/template.php
@@ -31,16 +31,15 @@ if (
 }
 ?>
 
-<details class="vf-details"<?php if ($is_preview) { echo ' open'; } ?>>
+<details class="vf-details"<?php if ($is_preview) { echo ' open="open"'; } ?>>
 <summary class="vf-details--summary">
 <?php echo esc_html($title); ?>
 </summary>
 <?php
+// Keep old WYSIWYG field for backwards compatibility
 if ( ! empty($summary)) {
   echo wpautop($summary);
 }
 ?>
-<?php if ( ! $is_preview) { ?>
 <InnerBlocks />
-<?php } ?>
 </details>

--- a/wp-content/themes/vf-wp/functions.php
+++ b/wp-content/themes/vf-wp/functions.php
@@ -31,7 +31,9 @@ require_once('blocks/vfwp-search/index.php');
 require_once('blocks/vfwp-masthead/index.php');
 require_once('blocks/vfwp-social-icons/index.php');
 
-
+if (vf_debug()) {
+  require_once('blocks/vfwp-debug/index.php');
+}
 
 global $vf_admin;
 if ( ! isset($vf_admin)) {
@@ -45,26 +47,26 @@ if ( ! isset($vf_theme)) {
 
 // adds contact box to WP admin dashboard
 add_action('wp_dashboard_setup', 'contact_box');
-  
+
 function contact_box() {
 global $wp_meta_boxes;
- 
+
 wp_add_dashboard_widget('custom_help_widget', 'Share your feedback', 'contact_box_content');
 }
- 
+
 function contact_box_content() {
 echo '<div style="background-color: #fffadc; padding: 3px;"><p>If you have any questions, comments or suggestions please send your feedback to <a href="mailto:digital-comms@embl.org">digital-comms@embl.org</a>.</p></div>';
 }
 
 // adds training box to WP admin dashboard
 add_action('wp_dashboard_setup', 'training_box');
-  
+
 function training_box() {
 global $wp_meta_boxes;
- 
+
 wp_add_dashboard_widget('custom_training_widget', 'WordPress Training Materials', 'training_box_content');
 }
- 
+
 function training_box_content() {
 echo '<div style="background-color: #fffadc; padding: 3px;"><p>To learn more about WordPress, blocks, page templates, customization and more, check out our <a href="https://wwwdev.embl.org/guidelines/design/page/wordpress/">training materials</a>.</p></div>';
 }

--- a/wp-content/themes/vf-wp/functions/theme-block.php
+++ b/wp-content/themes/vf-wp/functions/theme-block.php
@@ -69,7 +69,7 @@ class VFWP_Block {
       $config['supports']['jsx'] = $config['supports']['vf/innerBlocks'];
     }
     // Setup render callback using VF Gutenberg plugin or fallback
-    $config['render_callback'] = function() {
+    $callback = function() use ($config) {
       $args = func_get_args();
       $template = $this->get_template();
       // Render block in iFrame by default if plugin exists
@@ -90,7 +90,12 @@ class VFWP_Block {
       }
     };
     // Register the Gutenberg block with ACF
-    acf_register_block_type($config);
+    acf_register_block_type(array_merge(
+      $config,
+      array(
+        'render_callback' => $callback
+      )
+    ));
     // Add "Full-width Layout" settings for container blocks
     if ($this->is_containerable()) {
       acf_add_local_field_group(array(

--- a/wp-content/themes/vf-wp/functions/theme.php
+++ b/wp-content/themes/vf-wp/functions/theme.php
@@ -253,6 +253,11 @@ class VF_Theme {
       }
     }
 
+    // Add Visual Framework editor styles
+    if (in_array('editor-styles', $supports)) {
+      add_editor_style('assets/css/styles.css');
+    }
+
   }
 
   /**


### PR DESCRIPTION
Resolves #505 and work towards improving #325

This PR includes:

* [Editor styles](https://developer.wordpress.org/block-editor/developers/themes/theme-support/#editor-styles) support to include the Visual Framework stylesheet in the Gutenberg editor
* Additional WP admin styles to improve VF typography within the editor
* Support for Inner Blocks in the block config to render without an iframe
* Debug/example block
* **`vf-details`** block upgraded to use Inner Blocks