### PR TITLE
removing deprecated vf-inlay grid

### DIFF
--- a/wp-content/plugins/vf-group-header-block/template.php
+++ b/wp-content/plugins/vf-group-header-block/template.php
@@ -87,14 +87,13 @@ if (vf_cache_empty($content)) {
 
 ?>
 <?php if ( ! $is_minimal) { ?>
-<section class="vf-inlay">
-  <div class="vf-inlay__content vf-u-background-color-ui--white">
+<div class="vf-grid vf-grid__col-3 | vf-u-margin__bottom--800">
   <?php if ( ! vf_cache_empty($heading)) { ?>
-    <main class="vf-inlay__content--main">
+    <div class="vf-grid__col--span-2">
       <?php echo $heading; ?>
-    </main>
+    </div>
   <?php } ?>
-    <aside class="vf-inlay__content--additional">
+    <div>
 <?php } // is_minimal ?>
 
     <?php
@@ -109,7 +108,6 @@ if (vf_cache_empty($content)) {
     ?>
 
 <?php if ( ! $is_minimal) { ?>
-    </aside>
   </div>
-</section>
+</div>
 <?php } // is_minimal ?>

--- a/wp-content/themes/vf-wp-groups/attachment.php
+++ b/wp-content/themes/vf-wp-groups/attachment.php
@@ -3,18 +3,16 @@
 get_header();
 
 ?>
-<section class="vf-inlay">
-  <div class="vf-inlay__content vf-u-background-color-ui--white">
-    <main class="vf-inlay__content--main">
+<div class="vf-grid">
+    <div>
       <h1 class="vf-text vf-text-heading--1">
         <?php the_title(); ?>
       </h1>
       <div class="vf-content">
         <?php echo wp_get_attachment_image( get_the_ID(), 'large' ); ?>
       </div>
-    </main>
-  </div>
-</section>
+    </div>
+</div>
 <?php
 
 get_footer();

--- a/wp-content/themes/vf-wp-groups/index.php
+++ b/wp-content/themes/vf-wp-groups/index.php
@@ -7,9 +7,8 @@ global $vf_theme;
 $title = $vf_theme->get_title();
 
 ?>
-<section class="vf-inlay">
-  <div class="vf-inlay__content vf-u-background-color-ui--white">
-    <main class="vf-inlay__content--main">
+<div class="vf-grid vf-grid__col-3 | vf-u-grid-gap--800">
+    <div class="vf-grid__col--span-2">
       <h1 class="vf-text vf-text-heading--1">
         <?php echo esc_html($title); ?>
       </h1>
@@ -23,14 +22,13 @@ $title = $vf_theme->get_title();
       }
       vf_pagination();
       ?>
-    </main>
+    </div>
     <?php if (is_active_sidebar('sidebar-blog')) { ?>
-    <aside class="vf-inlay__content--additional">
+    <div>
       <?php vf_sidebar('sidebar-blog'); ?>
-    </aside>
+    </div>
     <?php } ?>
-  </div>
-</section>
+</div>
 <?php
 
 get_footer();

--- a/wp-content/themes/vf-wp-groups/singular.php
+++ b/wp-content/themes/vf-wp-groups/singular.php
@@ -8,50 +8,53 @@ setup_postdata($post);
 global $vf_theme;
 
 ?>
-  <div class="vf-grid vf-grid__col-3 | vf-u-grid-gap--800 | vf-content">
-    <div class="vf-grid__col--span-2">
-      <h1>
-        <?php the_title(); ?>
-      </h1>
-      <div class="vf-meta__details">
-        <p class="vf-author__name"><span class="vf-meta__date"><time title="<?php the_time('c'); ?>"
-          datetime="<?php the_time('c'); ?>"><?php the_time(get_option('date_format')); ?></time></span>, by <a class="vf-link" href="<?php echo get_author_posts_url( get_the_author_meta( 'ID' ) ); ?>"><?php the_author(); ?></a> in <?php echo get_the_category_list(','); ?>
-        </p>
-      </div>
-    </div>
-    
-    <div></div>
-  </div>
 <div class="vf-grid vf-grid__col-3 | vf-u-grid-gap--800 | vf-content">
-    <div class="vf-grid__col--span-2">
+  <div class="vf-grid__col--span-2">
+    <h1>
+      <?php the_title(); ?>
+    </h1>
+    <div class="vf-meta__details">
+      <p class="vf-author__name"><span class="vf-meta__date"><time title="<?php the_time('c'); ?>"
+            datetime="<?php the_time('c'); ?>"><?php the_time(get_option('date_format')); ?></time></span>, by <a
+          class="vf-link"
+          href="<?php echo get_author_posts_url( get_the_author_meta( 'ID' ) ); ?>"><?php the_author(); ?></a> in
+        <?php echo get_the_category_list(','); ?>
+      </p>
+    </div>
+  </div>
 
-      <?php
+  <div></div>
+</div>
+<div class="vf-grid vf-grid__col-3 | vf-u-grid-gap--800 | vf-content">
+  <div class="vf-grid__col--span-2">
+
+    <?php
       if (has_post_thumbnail()) {
         $caption = get_the_post_thumbnail_caption();
       ?>
-      <figure class="vf-figure">
-          <?php the_post_thumbnail('full', array('class' => 'vf-figure__image | vf-u-margin__bottom--200')); ?>
-          <?php if ( ! vf_html_empty($caption)) { ?>
-          <figcaption class="vf-figure__caption">
-            <?php echo esc_html($caption); ?>
-          </figcaption>
-          <?php } ?>
-        </figure>
+    <figure class="vf-figure">
+      <?php the_post_thumbnail('full', array('class' => 'vf-figure__image | vf-u-margin__bottom--200')); ?>
+      <?php if ( ! vf_html_empty($caption)) { ?>
+      <figcaption class="vf-figure__caption">
+        <?php echo esc_html($caption); ?>
+      </figcaption>
       <?php } ?>
+    </figure>
+    <?php } ?>
 
-      <?php
+    <?php
 
       // the_content();
       $vf_theme->the_content();
 
       ?>
-      <?php
+    <?php
     $tags = get_the_tags($post->ID);
     if (is_array($tags)) {
     ?>
     <p class="vf-text--body vf-text-body--3">
       <?php esc_html_e('Tags:', 'vfwp'); ?>
-    <?php
+      <?php
       $tagslist = array();
       foreach($tags as $tag) {
         $tagslist[] = '<a  href="'
@@ -66,20 +69,20 @@ global $vf_theme;
     ?>
     </p>
     <?php } ?>
-      <?php
+    <?php
       if (comments_open() || get_comments_number()) {
         comments_template();
       }
       ?>
-    </div>
-    <?php if (is_active_sidebar('sidebar-blog')) { ?>
+  </div>
+  <?php if (is_active_sidebar('sidebar-blog')) { ?>
 
-    <div>
+  <div>
     <?php vf_sidebar('sidebar-blog'); ?>
-    </div>
+  </div>
 
-    <?php } ?>
-    </div>
+  <?php } ?>
+</div>
 <?php
 
 get_footer();

--- a/wp-content/themes/vf-wp-groups/singular.php
+++ b/wp-content/themes/vf-wp-groups/singular.php
@@ -8,23 +8,22 @@ setup_postdata($post);
 global $vf_theme;
 
 ?>
-<section class="vf-inlay">
-  <div class="vf-inlay__content vf-u-background-color-ui--white | vf-content">
-    <main class="vf-inlay__content--main">
+  <div class="vf-grid vf-grid__col-3 | vf-u-grid-gap--800 | vf-content">
+    <div class="vf-grid__col--span-2">
       <h1>
         <?php the_title(); ?>
       </h1>
       <div class="vf-meta__details">
-      <p class="vf-author__name | vf-u-margin__bottom--0"><span class="vf-meta__date"><time title="<?php the_time('c'); ?>"
-        datetime="<?php the_time('c'); ?>"><?php the_time(get_option('date_format')); ?></time></span>, by <a class="vf-link" href="<?php echo get_author_posts_url( get_the_author_meta( 'ID' ) ); ?>"><?php the_author(); ?></a> in <?php echo get_the_category_list(','); ?>
-</p>
-</div>
-    </main>
-
-    <aside class="vf-inlay__content--additional">
-      </aside>
-
-    <main class="vf-inlay__content--main">
+        <p class="vf-author__name"><span class="vf-meta__date"><time title="<?php the_time('c'); ?>"
+          datetime="<?php the_time('c'); ?>"><?php the_time(get_option('date_format')); ?></time></span>, by <a class="vf-link" href="<?php echo get_author_posts_url( get_the_author_meta( 'ID' ) ); ?>"><?php the_author(); ?></a> in <?php echo get_the_category_list(','); ?>
+        </p>
+      </div>
+    </div>
+    
+    <div></div>
+  </div>
+<div class="vf-grid vf-grid__col-3 | vf-u-grid-gap--800 | vf-content">
+    <div class="vf-grid__col--span-2">
 
       <?php
       if (has_post_thumbnail()) {
@@ -72,16 +71,15 @@ global $vf_theme;
         comments_template();
       }
       ?>
-    </main>
+    </div>
     <?php if (is_active_sidebar('sidebar-blog')) { ?>
 
-    <aside class="vf-inlay__content--additional ">
+    <div>
     <?php vf_sidebar('sidebar-blog'); ?>
-    </aside>
+    </div>
 
     <?php } ?>
-  </div>
-</section>
+    </div>
 <?php
 
 get_footer();

--- a/wp-content/themes/vf-wp-groups/template-jobs.php
+++ b/wp-content/themes/vf-wp-groups/template-jobs.php
@@ -24,9 +24,8 @@ $keyword = isset($_GET['filter_keyword']) ? vf_search_keyword($_GET['filter_keyw
 global $vf_theme;
 
 ?>
-<section class="vf-inlay">
-  <div class="vf-inlay__content vf-u-background-color-ui--white">
-    <main class="vf-inlay__content--main">
+<div class="vf-grid vf-grid__col-3 | vf-u-grid-gap--800">
+    <div class="vf-grid__col--span-2">
       <h1 class="vf-text vf-text-heading--1">
         <?php the_title(); ?>
       </h1>
@@ -36,8 +35,8 @@ global $vf_theme;
       $vf_theme->the_content();
 
       ?>
-    </main>
-    <aside class="vf-inlay__content--additional">
+    </div>
+    <div>
       <form role="search" class="vf-form | vf-search vf-search--inline" method="get" action="<?php the_permalink(); ?>">
         <div class="vf-form__item | vf-search__item">
           <label class="vf-form__label vf-sr-only | vf-search__label" for="filter_keyword"><?php _e('Search jobs by keyword:', 'vfwp'); ?></label>
@@ -45,9 +44,8 @@ global $vf_theme;
         </div>
         <input type="submit" class="vf-search__button | vf-button vf-button--primary" value="<?php esc_attr_e('Search', 'vfwp'); ?>">
       </form>
-    </aside>
-  </div>
-</section>
+    </div>
+</div>
 <?php
 
 /**

--- a/wp-content/themes/vf-wp-groups/template-members.php
+++ b/wp-content/themes/vf-wp-groups/template-members.php
@@ -16,9 +16,8 @@ get_header();
 global $vf_theme;
 
 ?>
-<section class="vf-inlay">
-  <div class="vf-inlay__content vf-u-background-color-ui--white">
-    <main class="vf-inlay__content--full-width">
+<div class="vf-grid">
+  <div>
       <h1 class="vf-text vf-text-heading--1">
         <?php the_title(); ?>
       </h1>
@@ -36,12 +35,12 @@ global $vf_theme;
       }
 
       // the_content();
-      include('wp-content/plugins/vf-members-block/template.php')
-
+      echo '<div>';
+      VF_Plugin::render($vf_members);
+      echo '</div>';
       ?>
-    </main>
   </div>
-</section>
+</div>
 <?php
 
 get_footer();

--- a/wp-content/themes/vf-wp-groups/template-publications.php
+++ b/wp-content/themes/vf-wp-groups/template-publications.php
@@ -18,9 +18,8 @@ $keyword = $vf_publications->get_query_keyword();
 global $vf_theme;
 
 ?>
-<section class="vf-inlay">
-  <div class="vf-inlay__content vf-u-background-color-ui--white">
-    <main class="vf-inlay__content--main">
+  <div class="vf-grid vf-grid__col-3 | vf-u-grid-gap--800">
+    <div class="vf-grid__col--span-2">
       <h1 class="vf-text vf-text-heading--1">
         <?php the_title(); ?>
       </h1>
@@ -34,7 +33,6 @@ global $vf_theme;
       $vf_theme->the_content();
 
       ?>
-    </main>
     <?php /*
     <aside class="vf-inlay__content--additional">
       <form id="publications-filter" role="search" method="get" action="<?php the_permalink(); ?>">
@@ -70,7 +68,7 @@ global $vf_theme;
     </aside>
     */ ?>
   </div>
-</section>
+</div>
 <?php
 
 get_footer();

--- a/wp-content/themes/vf-wp-groups/template-with-sidebar.php
+++ b/wp-content/themes/vf-wp-groups/template-with-sidebar.php
@@ -7,9 +7,8 @@ get_header();
 $title = get_the_title();
 ?>
 
-  <section class="vf-inlay">
-  <div class="vf-inlay__content vf-u-background-color-ui--white">
-    <main class="vf-inlay__content--main">
+  <div class="vf-grid vf-grid__col-3 vf-u-grid-gap--800">
+    <div class="vf-grid__col--span-2">
       <h1 class="vf-text vf-text-heading--1">
         <?php echo esc_html($title); ?>
       </h1>
@@ -19,14 +18,13 @@ $title = get_the_title();
       $vf_theme->the_content();
 
       ?>
-    </main>
+    </div>
     <?php if (is_active_sidebar('sidebar-page')) { ?>
-    <aside class="vf-inlay__content--additional">
+    <div>
       <?php vf_sidebar('sidebar-page'); ?>
-    </aside>
+    </div>
     <?php } ?>
-  </div>
-</section>
+</div>
 
 <?php
 

--- a/wp-content/themes/vf-wp-news/application-pdf.php
+++ b/wp-content/themes/vf-wp-news/application-pdf.php
@@ -17,7 +17,7 @@ $attachment_id = wp_get_attachment_url();
   </div>
 </main>
 
-<section class="vf-inlay">
+<section class="vf-grid">
   <?php include(locate_template('partials/newsletter-container.php', false, false)); ?>
 </section>
 

--- a/wp-content/themes/vf-wp-news/attachment.php
+++ b/wp-content/themes/vf-wp-news/attachment.php
@@ -35,7 +35,7 @@ $attachment_id = wp_get_attachment_url();
 </div>
 
 </main>
-<section class="vf-inlay">
+<section class="vf-grid">
 
 <?php include(locate_template('partials/newsletter-container.php', false, false)); ?>
 </section>

--- a/wp-content/themes/vf-wp-news/page.php
+++ b/wp-content/themes/vf-wp-news/page.php
@@ -4,22 +4,16 @@ get_header();
 
 the_post();
 
-
 ?>
-<section class="vf-inlay">
-  <div class="vf-inlay__content vf-u-background-color-ui--white">
-    <main class="vf-inlay__content--main">
-
-      <h1 class="vf-text vf-text--display-l"><?php the_title(); ?></h1>
-
-      <?php the_content(); ?>
-
-    </main>
-    <?php if (is_active_sidebar('sidebar-page')) { ?>
-    <aside class="vf-inlay__content--additional">
-      <?php vf_sidebar('sidebar-page'); ?>
-    </aside>
-    <?php } ?>
+<div class="vf-grid vf-grid__col-3 | vf-u-grid-gap--800">
+  <div class="vf-grid__col--span-2">
+    <h1 class="vf-text vf-text--display-l"><?php the_title(); ?></h1>
+    <?php the_content(); ?>
   </div>
-</section>
+  <?php if (is_active_sidebar('sidebar-page')) { ?>
+  <div>
+    <?php vf_sidebar('sidebar-page'); ?>
+  </div>
+  <?php } ?>
+</div>
 <?php get_footer(); ?>

--- a/wp-content/themes/vf-wp/404.php
+++ b/wp-content/themes/vf-wp/404.php
@@ -3,15 +3,13 @@
 get_header();
 
 ?>
-<section class="vf-inlay">
-  <div class="vf-inlay__content vf-u-background-color-ui--white">
-    <main class="vf-inlay__content--main">
+<div class="vf-grid">
+  <div>
       <h1 class="vf-text vf-text-heading--1">
         <?php _e('404 page not found.'); ?>
       </h1>
-    </main>
   </div>
-</section>
+</div>
 <?php
 
 get_footer();

--- a/wp-content/themes/vf-wp/template-with-sidebar.php
+++ b/wp-content/themes/vf-wp/template-with-sidebar.php
@@ -7,9 +7,8 @@ get_header();
 $title = get_the_title();
 ?>
 
-  <section class="vf-inlay">
-  <div class="vf-inlay__content vf-u-background-color-ui--white">
-    <main class="vf-inlay__content--main">
+<div class="vf-grid vf-grid__col-3 vf-u-grid-gap--800">
+    <div class="vf-grid__col--span-2">
       <h1 class="vf-text vf-text-heading--1">
         <?php echo esc_html($title); ?>
       </h1>
@@ -19,16 +18,16 @@ $title = get_the_title();
       $vf_theme->the_content();
 
       ?>
-    </main>
+    </div>
     <?php if (is_active_sidebar('sidebar-page')) { ?>
-    <aside class="vf-inlay__content--additional">
+    <div>
       <?php vf_sidebar('sidebar-page'); ?>
-    </aside>
+    </div>
     <?php } ?>
-  </div>
-</section>
+</div>
 
 <?php
 
 get_footer();
 ?>
+


### PR DESCRIPTION
This removes `vf-inlay` grid from page and block templates and replaces it with `vf-grid vf-grid__col-3`

Examples:

Before:
![Screenshot 2020-10-28 at 12 25 10](https://user-images.githubusercontent.com/54020899/97430485-3ccee180-1919-11eb-9993-ea9c6ab069fe.png)

After:
![Screenshot 2020-10-28 at 12 02 25](https://user-images.githubusercontent.com/54020899/97430506-41939580-1919-11eb-90b7-3568081d9d70.png)

Before:
![Screenshot 2020-10-28 at 12 24 57](https://user-images.githubusercontent.com/54020899/97430520-47897680-1919-11eb-9f07-f8bce2fd37e1.png)

After:
![Screenshot 2020-10-28 at 11 59 43](https://user-images.githubusercontent.com/54020899/97430533-4d7f5780-1919-11eb-9413-de554907ca13.png)

