### PR TITLE
ehnchancement: responsive-wp-embed

### DIFF
--- a/wp-content/themes/vf-wp/functions/theme-content.php
+++ b/wp-content/themes/vf-wp/functions/theme-content.php
@@ -50,6 +50,16 @@ class VF_Theme_Content {
         $html
       );
     }
+
+    // wp-embed should use vf-embed for responsiveness
+    // https://github.com/visual-framework/vf-wp/issues/693
+    if ($block['blockName'] === 'core/embed') {
+      $html = preg_replace(
+        "wp-block-embed__wrapper",
+        "wp-block-embed__wrapper | vf-embed vf-embed--16x9",
+        $html
+      );
+    }
     return $html;
   }
 


### PR DESCRIPTION
This simple PR allows videos embedded by the standard WP video block and YouTube embed to be responsive using the VF CSS.

For #693