### PR TITLE
bug: vf-navigation list class

### DIFF
--- a/wp-content/plugins/vf-navigation-container/template.php
+++ b/wp-content/plugins/vf-navigation-container/template.php
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 
 ?>
 <nav class="vf-navigation vf-navigation--main | vf-cluster | vf-u-padding__top--0" style="margin-bottom: 1rem !important;">
-  <ul class="vf-navigation__list | vf-list--inline | vf-cluster__inner">
+  <ul class="vf-navigation__list | vf-list | vf-cluster__inner">
 <?php
 
 if (has_nav_menu('primary')) {

--- a/wp-content/themes/vf-wp-groups/vf-wp-groups-header/vf-navigation.php
+++ b/wp-content/themes/vf-wp-groups/vf-wp-groups-header/vf-navigation.php
@@ -4,7 +4,7 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 
 ?>
 <nav class="vf-navigation vf-navigation--main | vf-cluster">
-  <ul class="vf-navigation__list | vf-list--inline | vf-cluster__inner">
+  <ul class="vf-navigation__list | vf-list | vf-cluster__inner">
 <?php
 
 if (has_nav_menu('primary')) {

--- a/wp-content/themes/vf-wp-news/partials/vf-navigation.php
+++ b/wp-content/themes/vf-wp-news/partials/vf-navigation.php
@@ -1,5 +1,5 @@
-<nav class="vf-navigation vf-navigation--main">
-  <ul class="vf-navigation__list | vf-list--inline">
+<nav class="vf-navigation vf-navigation--main | vf-cluster">
+  <ul class="vf-navigation__list | vf-list | vf-cluster__inner">
 <?php
 
 if (has_nav_menu('primary')) {


### PR DESCRIPTION
vf-navigation no longer uses `vf-list--inline`. The old class is causing some chopped off text.

https://stable.visual-framework.dev/components/vf-navigation/#vf-navigation--main

![image](https://user-images.githubusercontent.com/928100/120496494-e699b380-c3bd-11eb-86c3-d7171beac6c4.png)
