### PR TITLE
Enhancement: rename "Team publications"

### DIFF
--- a/wp-content/plugins/vf-publications-block/index.php
+++ b/wp-content/plugins/vf-publications-block/index.php
@@ -20,7 +20,7 @@ class VF_Publications extends VF_Plugin {
 
   protected $config = array(
     'post_name'  => 'vf_publications',
-    'post_title' => 'Team publications',
+    'post_title' => 'Publications',
   );
 
   // Plugin uses Content Hub API


### PR DESCRIPTION
The "Team publications" block is often confusing as we use it query for individual person (name, ORCID, CPID) publications.

Renaming it to be just "Publications" is more obvious.

![image](https://user-images.githubusercontent.com/928100/121063980-4ed60400-c7c7-11eb-9d59-7fe79c3e140a.png)


![image](https://user-images.githubusercontent.com/928100/121063600-d2432580-c7c6-11eb-8960-c094cec3e5ad.png)

This came up in a recent conversation with @geetikamalhotra