### PR TITLE
Bug: double cookie banner and EBI 1.3 vs 1.4 JS

### DIFF
--- a/wp-content/plugins/vf-ebi-global-footer-container/index.php
+++ b/wp-content/plugins/vf-ebi-global-footer-container/index.php
@@ -108,7 +108,7 @@ class VF_EBI_Global_Footer extends VF_Plugin {
     }
     wp_enqueue_script(
       'ebi-framework--defer',
-      'https://dev.ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.4/js/script.js',
+      'https://ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.4/js/script.js',
       false,
       'v1.4',
       true
@@ -132,7 +132,7 @@ class VF_EBI_Global_Footer extends VF_Plugin {
     );
     wp_enqueue_style(
       'ebi-fonts',
-      'https://dev.ebi.emblstatic.net/web_guidelines/EBI-Icon-fonts/v1.3/fonts.css',
+      'https://ebi.emblstatic.net/web_guidelines/EBI-Icon-fonts/v1.3/fonts.css',
       array(),
       'v1.3',
       'all'

--- a/wp-content/plugins/vf-ebi-global-footer-container/index.php
+++ b/wp-content/plugins/vf-ebi-global-footer-container/index.php
@@ -108,9 +108,9 @@ class VF_EBI_Global_Footer extends VF_Plugin {
     }
     wp_enqueue_script(
       'ebi-framework--defer',
-      'https://dev.ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.3/js/script.js',
+      'https://dev.ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.4/js/script.js',
       false,
-      'v1.3',
+      'v1.4',
       true
     );
     // wp_enqueue_style(

--- a/wp-content/plugins/vf-ebi-global-header-container/template.php
+++ b/wp-content/plugins/vf-ebi-global-header-container/template.php
@@ -53,7 +53,7 @@ $content = preg_replace(
   $content
 );
 
-// If EBI 1.x JS runs, disable the legacy cookie banner (2.0 will deliver the banner instead)
+// If EBI 1.4 JS runs, disable the legacy cookie banner (2.0 will deliver the banner instead)
 // https://stable.visual-framework.dev/components/ebi-header-footer/
 $content .= '<div data-protection-message-disable="true" class="vf-u-display-none"></div>';
 


### PR DESCRIPTION
The option to prevent double cookie banners (old 1.3 cookie banner) is only supported in EBI VF 1.4 JS. Which we should use in any case.

This fixes that.

```
// If EBI 1.4 JS runs, disable the legacy cookie banner (2.0 will deliver the banner instead)
// https://stable.visual-framework.dev/components/ebi-header-footer/
$content .= '<div data-protection-message-disable="true" class="vf-u-display-none"></div>';
```