### PR TITLE
fix: Ensure styles are being applied to vf-column-grid appender button

### DIFF
--- a/vf-components/vfwp-admin/vfwp-admin.css
+++ b/vf-components/vfwp-admin/vfwp-admin.css
@@ -495,6 +495,13 @@
 .editor-styles-wrapper .vf-details[open] .vf-details--summary {
   pointer-events: none;
 }
+.editor-styles-wrapper .wp-block-vf-grid-column .block-list-appender.wp-block {
+  -ms-flex-item-align: center;
+      align-self: center;
+  padding: 0;
+  list-style: none;
+  margin: 8px !important;
+}
 
 .block-editor .editor-styles-wrapper .has-extra-large-font-size {
   font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;

--- a/vf-components/vfwp-admin/vfwp-admin.css
+++ b/vf-components/vfwp-admin/vfwp-admin.css
@@ -501,6 +501,7 @@
   padding: 0;
   list-style: none;
   margin: 8px !important;
+  max-width: 100%;
 }
 
 .block-editor .editor-styles-wrapper .has-extra-large-font-size {

--- a/vf-components/vfwp-admin/vfwp-admin.scss
+++ b/vf-components/vfwp-admin/vfwp-admin.scss
@@ -96,6 +96,13 @@
       pointer-events: none;
     }
   }
+
+  .wp-block-vf-grid-column .block-list-appender.wp-block {
+    align-self: center;
+    padding: 0;
+    list-style: none;
+    margin: 8px !important;
+  }
 }
 
 // Include custom typography styles within editor

--- a/vf-components/vfwp-admin/vfwp-admin.scss
+++ b/vf-components/vfwp-admin/vfwp-admin.scss
@@ -102,6 +102,7 @@
     padding: 0;
     list-style: none;
     margin: 8px !important;
+    max-width: 100%;
   }
 }
 

--- a/wp-content/themes/vf-wp/assets/assets/vfwp-admin/vfwp-admin.css
+++ b/wp-content/themes/vf-wp/assets/assets/vfwp-admin/vfwp-admin.css
@@ -495,6 +495,13 @@
 .editor-styles-wrapper .vf-details[open] .vf-details--summary {
   pointer-events: none;
 }
+.editor-styles-wrapper .wp-block-vf-grid-column .block-list-appender.wp-block {
+  -ms-flex-item-align: center;
+      align-self: center;
+  padding: 0;
+  list-style: none;
+  margin: 8px !important;
+}
 
 .block-editor .editor-styles-wrapper .has-extra-large-font-size {
   font-family: "IBM Plex Sans", Helvetica, Arial, sans-serif;

--- a/wp-content/themes/vf-wp/assets/assets/vfwp-admin/vfwp-admin.css
+++ b/wp-content/themes/vf-wp/assets/assets/vfwp-admin/vfwp-admin.css
@@ -501,6 +501,7 @@
   padding: 0;
   list-style: none;
   margin: 8px !important;
+  max-width: 100%;
 }
 
 .block-editor .editor-styles-wrapper .has-extra-large-font-size {


### PR DESCRIPTION
These styles are required because without them, the appender button in the vf-column-grid takes all space and it's impossible to select the column to change the span (if applicable)