### PR TITLE
Fix: VF-WP Navigation plugin

### DIFF
--- a/wp-content/plugins/vf-navigation-container/index.php
+++ b/wp-content/plugins/vf-navigation-container/index.php
@@ -47,7 +47,7 @@ class VF_Navigation extends VF_Plugin {
    */
   public function nav_menu_css_class($classes, $item, $args, $depth) {
     if (in_array($args->theme_location, array('primary', 'secondary'))) {
-      return ['vf-navigation__item'];
+      $classes[] = 'vf-navigation__item';
     }
     return $classes;
   }


### PR DESCRIPTION
While trying to add specific styles to a main menu while building the new INDSC.org site, I found the VF-WP navigation plugin was removing useful classes from menu items, like 'current-item-menu' which are generated by `wp_nav_menu` function. The fix is only pushing the specific VF class to the classes array instead of returning a new array.